### PR TITLE
Cleanup existing sets and update to OCR 4.0 (pre-AD).

### DIFF
--- a/Sets/137511d8-0942-4075-8000-24fa4395c6ea/set.xml
+++ b/Sets/137511d8-0942-4075-8000-24fa4395c6ea/set.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<set name="Premiere" id="137511d8-0942-4075-8000-24fa4395c6ea" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="3.1.0.0" version="3.1">
+<set name="Premiere" id="137511d8-0942-4075-8000-24fa4395c6ea" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="2.2.4.4" version="3.2">
  <markers>
   <marker id="ec99fdcb-ffea-4658-8e8f-5dc06e93f6fd" name="action" />
  </markers>
  <cards>
   <card id="5ff3e6bf-84fb-4387-8931-cfd18710c93c" name="Rainbow Dash">
-   <property name="Number" value="001" />
+   <property name="Number" value="PR1" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Flier Extraordinaire" />
@@ -24,28 +24,28 @@
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
    <alternate name="Rainbow Dash" type="Mane Character Boosted">
-	   <property name="Number" value="001" />
-	   <property name="Type" value="Mane Character Boosted" />
-	   <property name="Element" value="Loyalty" />
-	   <property name="Subname" value="Flier Extraordinaire" />
-	   <property name="Power" value="3" />
-	   <property name="Cost" value="" />
-	   <property name="PlayRequiredPower" value="" />
-	   <property name="PlayRequiredElement" value="" />
-	   <property name="Traits" value="Pegasus" />
-	   <property name="Keywords" value="Home Limit 4, Swift." />
-	   <property name="Text" value="When you move this card from home to a Problem, you may pay 1 to move another one of your Friends from home to that Problem." />
-	   <property name="ProblemBonus" value="" />
-	   <property name="ProblemOpponentPower" value="" />
-	   <property name="ProblemPlayerElement1" value="" />
-	   <property name="ProblemPlayerElement1Power" value="" />
-	   <property name="ProblemPlayerElement2" value="" />
-	   <property name="ProblemPlayerElement2Power" value="" />
-	   <property name="Rarity" value="F" />
-   </alternate>   
+    <property name="Number" value="PR1" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Loyalty" />
+    <property name="Subname" value="Flier Extraordinaire" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Pegasus" />
+    <property name="Keywords" value="Home Limit 4, Swift." />
+    <property name="Text" value="When you move this card from home to a Problem, you may pay 1AT to move another one of your Friends from home to that Problem." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
   <card id="fbfe63a5-71e4-4b16-b735-9cfca17f8b45" name="Applejack">
-   <property name="Number" value="002" />
+   <property name="Number" value="PR2" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Steadfast Farmpony" />
@@ -64,148 +64,28 @@
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
    <alternate name="Applejack" type="Mane Character Boosted">
-	   <property name="Number" value="002" />
-	   <property name="Type" value="Mane Character Boosted" />
-	   <property name="Element" value="Honesty" />
-	   <property name="Subname" value="Steadfast Farmpony" />
-	   <property name="Power" value="3" />
-	   <property name="Cost" value="" />
-	   <property name="PlayRequiredPower" value="" />
-	   <property name="PlayRequiredElement" value="" />
-	   <property name="Traits" value="Earth Pony" />
-	   <property name="Keywords" value="Home Limit 4, Stubborn." />
-	   <property name="Text" value="When one of your Friends with this card at home or a Problem is dismissed, you may put it on the top of your deck." />
-	   <property name="ProblemBonus" value="" />
-	   <property name="ProblemOpponentPower" value="" />
-	   <property name="ProblemPlayerElement1" value="" />
-	   <property name="ProblemPlayerElement1Power" value="" />
-	   <property name="ProblemPlayerElement2" value="" />
-	   <property name="ProblemPlayerElement2Power" value="" />
-	   <property name="Rarity" value="F" />
-   </alternate>   
-  </card>
-  <card id="935e02bc-b14d-4a49-ae4d-375f567fb3ac" name="Fluttershy">
-   <property name="Number" value="006" />
-   <property name="Type" value="Mane Character" />
-   <property name="Element" value="Kindness" />
-   <property name="Subname" value="Beastmaster" />
-   <property name="Power" value="1" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="When you confront this card's Problem and you have a [Critter] Friend at that Problem, turn this card over." />
-   <property name="ProblemBonus" value="" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="F" />
-   <alternate name="Fluttershy" type="Mane Character Boosted">
-	   <property name="Number" value="006" />
-	   <property name="Type" value="Mane Character Boosted" />
-	   <property name="Element" value="Kindness" />
-	   <property name="Subname" value="Beastmaster" />
-	   <property name="Power" value="3" />
-	   <property name="Cost" value="" />
-	   <property name="PlayRequiredPower" value="" />
-	   <property name="PlayRequiredElement" value="" />
-	   <property name="Traits" value="Pegasus" />
-	   <property name="Keywords" value="Home Limit 5, Caretaker." />
-	   <property name="Text" value="When this card is involved in a faceoff, you may move a [Critter] to this card's Problem for free." />
-	   <property name="ProblemBonus" value="" />
-	   <property name="ProblemOpponentPower" value="" />
-	   <property name="ProblemPlayerElement1" value="" />
-	   <property name="ProblemPlayerElement1Power" value="" />
-	   <property name="ProblemPlayerElement2" value="" />
-	   <property name="ProblemPlayerElement2Power" value="" />
-	   <property name="Rarity" value="F" />
-   </alternate>   
-  </card>
-  <card id="e0ded2bf-41fe-4a02-bf7a-f269c5895840" name="Twilight Sparkle">
-   <property name="Number" value="004" />
-   <property name="Type" value="Mane Character" />
-   <property name="Element" value="Magic" />
-   <property name="Subname" value="Faithful Student" />
-   <property name="Power" value="1" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="When you win a faceoff involving this card, turn this card over." />
-   <property name="ProblemBonus" value="" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="F" />
-   <alternate name="Twilight Sparkle" type="Mane Character Boosted">
-	   <property name="Number" value="004" />
-	   <property name="Type" value="Mane Character Boosted" />
-	   <property name="Element" value="Magic" />
-	   <property name="Subname" value="Faithful Student" />
-	   <property name="Power" value="3" />
-	   <property name="Cost" value="" />
-	   <property name="PlayRequiredPower" value="" />
-	   <property name="PlayRequiredElement" value="" />
-	   <property name="Traits" value="Unicorn" />
-	   <property name="Keywords" value="Home Limit 4, Studious." />
-	   <property name="Text" value="After a faceoff involving this card, you may put any Events you flipped into your hand instead of the bottom of your deck." />
-	   <property name="ProblemBonus" value="" />
-	   <property name="ProblemOpponentPower" value="" />
-	   <property name="ProblemPlayerElement1" value="" />
-	   <property name="ProblemPlayerElement1Power" value="" />
-	   <property name="ProblemPlayerElement2" value="" />
-	   <property name="ProblemPlayerElement2Power" value="" />
-	   <property name="Rarity" value="F" />
-   </alternate>   
-  </card>
-  <card id="10e394e3-6437-49bb-b836-ab20f49c92b7" name="Rarity">
-   <property name="Number" value="005" />
-   <property name="Type" value="Mane Character" />
-   <property name="Element" value="Generosity" />
-   <property name="Subname" value="Dazzling Fashionista" />
-   <property name="Power" value="1" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="When you score at least 2 points at this card's Problem during one Score Phase, turn this card over." />
-   <property name="ProblemBonus" value="" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="F" />
-   <alternate name="Rarity" type="Mane Character Boosted">
-	   <property name="Number" value="005" />
-	   <property name="Type" value="Mane Character Boosted" />
-	   <property name="Element" value="Generosity" />
-	   <property name="Subname" value="Dazzling Fashionista" />
-	   <property name="Power" value="3" />
-	   <property name="Cost" value="" />
-	   <property name="PlayRequiredPower" value="" />
-	   <property name="PlayRequiredElement" value="" />
-	   <property name="Traits" value="Unicorn" />
-	   <property name="Keywords" value="Home Limit 4, Inspired." />
-	   <property name="Text" value="Your opponet must pay +1 to move a character to this card's Problem." />
-	   <property name="ProblemBonus" value="" />
-	   <property name="ProblemOpponentPower" value="" />
-	   <property name="ProblemPlayerElement1" value="" />
-	   <property name="ProblemPlayerElement1Power" value="" />
-	   <property name="ProblemPlayerElement2" value="" />
-	   <property name="ProblemPlayerElement2Power" value="" />
-	   <property name="Rarity" value="F" />
-	   </alternate>
+    <property name="Number" value="PR2" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Honesty" />
+    <property name="Subname" value="Steadfast Farmpony" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Earth Pony" />
+    <property name="Keywords" value="Home Limit 4, Stubborn." />
+    <property name="Text" value="When one of your Friends here would be dismissed, you may put that Friend on top of your deck instead." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
   <card id="7a6d06b9-e09e-4c73-930b-0b62a36b4588" name="Pinkie Pie">
-   <property name="Number" value="003" />
+   <property name="Number" value="PR3" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Party Animal" />
@@ -224,28 +104,148 @@
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
    <alternate name="Pinkie Pie" type="Mane Character Boosted">
-      <property name="Number" value="003" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Laughter" />
-      <property name="Subname" value="Party Animal" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Earth Pony" />
-      <property name="Keywords" value="Home Limit 5, Random." />
-      <property name="Text" value="Your opponent needs +1 [Any] to confront this card's Problem." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="F" />
-    </alternate>
+    <property name="Number" value="PR3" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Laughter" />
+    <property name="Subname" value="Party Animal" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Earth Pony" />
+    <property name="Keywords" value="Home Limit 5, Random." />
+    <property name="Text" value="Your opponent needs +1 power to confront this card's Problem." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
+  </card>
+  <card id="e0ded2bf-41fe-4a02-bf7a-f269c5895840" name="Twilight Sparkle">
+   <property name="Number" value="PR4" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Magic" />
+   <property name="Subname" value="Faithful Student" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Unicorn" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you win a faceoff involving this card, turn this card over." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="F" />
+   <alternate name="Twilight Sparkle" type="Mane Character Boosted">
+    <property name="Number" value="PR4" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Magic" />
+    <property name="Subname" value="Faithful Student" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Unicorn" />
+    <property name="Keywords" value="Home Limit 4, Studious." />
+    <property name="Text" value="During a faceoff involving this card, if you would put a flipped Event card on the bottom of your deck, you may put it into your hand instead." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
+  </card>
+  <card id="10e394e3-6437-49bb-b836-ab20f49c92b7" name="Rarity">
+   <property name="Number" value="PR5" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Generosity" />
+   <property name="Subname" value="Dazzling Fashionista" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Unicorn" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you score at least 2 points with this card during one Score Phase, turn this card over." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="F" />
+   <alternate name="Rarity" type="Mane Character Boosted">
+    <property name="Number" value="PR5" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Generosity" />
+    <property name="Subname" value="Dazzling Fashionista" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Unicorn" />
+    <property name="Keywords" value="Home Limit 4, Inspired." />
+    <property name="Text" value="Your opponent must pay +1AT to move a character to this card's Problem." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
+  </card>
+  <card id="935e02bc-b14d-4a49-ae4d-375f567fb3ac" name="Fluttershy">
+   <property name="Number" value="PR6" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Kindness" />
+   <property name="Subname" value="Beastmaster" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Pegasus" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you confront this card's Problem, if you have a Critter Friend at that Problem, turn this card over." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="F" />
+   <alternate name="Fluttershy" type="Mane Character Boosted">
+    <property name="Number" value="PR6" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Kindness" />
+    <property name="Subname" value="Beastmaster" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Pegasus" />
+    <property name="Keywords" value="Home Limit 5, Caretaker." />
+    <property name="Text" value="At the start of a faceoff involving this card, you may move a Critter Friend to this card's Problem." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
   <card id="eb8df8fc-d7a5-410c-9e3f-d914bf73e3d3" name="Jetstream">
-   <property name="Number" value="007" />
+   <property name="Number" value="PR7" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="All Heart" />
@@ -255,7 +255,7 @@
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When involved in a faceoff, this card gets +2 power." />
+   <property name="Text" value="While involved in a faceoff, this card gets +2 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -265,7 +265,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="ffc99132-7001-4a4f-bc31-2ef202266298" name="Cerulean Skies">
-   <property name="Number" value="008" />
+   <property name="Number" value="PR8" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Skyward Soarer" />
@@ -274,8 +274,8 @@
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Swift." />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Swift." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -285,7 +285,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="4a60748b-bb70-416a-979a-973f98095b44" name="Finish Line">
-   <property name="Number" value="009" />
+   <property name="Number" value="PR9" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Jammer" />
@@ -294,18 +294,18 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Earth Pony, Foal" />
-   <property name="Keywords" value="Swift." />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Swift." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="C" />
+   <property name="Rarity" value="U" />
   </card>
   <card id="da6afcf9-e479-4941-96cb-234d97a7a8bd" name="Wild Fire">
-   <property name="Number" value="010" />
+   <property name="Number" value="PR10" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Speed Racer" />
@@ -325,7 +325,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="a5b7c9d8-0747-4910-a6ca-aabedf7dd3dc" name="Cloudchaser">
-   <property name="Number" value="011" />
+   <property name="Number" value="PR11" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Flexible Flier" />
@@ -335,7 +335,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card to reduce by 1 the cost of the next Friend you play this turn." />
+   <property name="Text" value="Main Phase: Exhaust this card to reduce by 1AT the cost of the next Friend you play this turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -345,10 +345,10 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="3b4aa10e-9174-4ce6-a51e-b0fa46ed6d45" name="Emerald Green">
-   <property name="Number" value="012" />
+   <property name="Number" value="PR12" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
-   <property name="Subname" value="Cider Afficionado" />
+   <property name="Subname" value="Cider Aficionado" />
    <property name="Power" value="2" />
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="" />
@@ -365,7 +365,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="b16e88dc-676c-4ef2-9ef7-3852791ef374" name="Holly Dash">
-   <property name="Number" value="013" />
+   <property name="Number" value="PR13" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Flighty Filly" />
@@ -385,7 +385,7 @@
    <property name="Rarity" value="F" />
   </card>
   <card id="2c6b5504-2d2a-4963-8785-94f950d4d030" name="Pegasus Royal Guard">
-   <property name="Number" value="014" />
+   <property name="Number" value="PR14" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Elite Sentry" />
@@ -405,7 +405,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="cd9c1d5f-9bf0-49e7-a889-30fece22eb7a" name="Rainbow Dash">
-   <property name="Number" value="015" />
+   <property name="Number" value="PR15" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Weather Leader" />
@@ -425,7 +425,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="6e8d157b-8de5-4364-b7ea-f10faabec45e" name="Rainbowshine">
-   <property name="Number" value="016" />
+   <property name="Number" value="PR16" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Cloud Wrangler" />
@@ -445,7 +445,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="ccb18ed9-0086-4630-a17e-1a9e4adfea5d" name="Scootaloo">
-   <property name="Number" value="017" />
+   <property name="Number" value="PR17" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Creature Catcher" />
@@ -465,7 +465,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="3b28c5c1-25fe-4223-bce9-7587e2d9d374" name="Spike">
-   <property name="Number" value="018" />
+   <property name="Number" value="PR18" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Baby Dragon" />
@@ -474,8 +474,8 @@
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Dragon" />
-   <property name="Keywords" value="Swift" />
-   <property name="Text" value="Main Phase: Pay 1 to give this card +1 power until the end of the turn." />
+   <property name="Keywords" value="Swift." />
+   <property name="Text" value="Main Phase: Pay 1AT to give this card +1 power until the end of the turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -485,7 +485,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="67dfe7c2-02a1-4ea8-a129-5ac1275b4d55" name="Solar Wind">
-   <property name="Number" value="019" />
+   <property name="Number" value="PR19" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Enterprising Astronomer" />
@@ -495,7 +495,7 @@
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play a [Pegasus] Friend to this card's Problem, you may exhaust this card. If you do, gain 1." />
+   <property name="Text" value="When you play a Pegasus Friend to this card's Problem, you may exhaust this card. If you do, gain 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -505,7 +505,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="a4d82a6e-85ad-4b3f-b8c2-16a6cee6522a" name="Sweetie Sunrise">
-   <property name="Number" value="020" />
+   <property name="Number" value="PR20" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Early Riser" />
@@ -525,7 +525,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="5fce3827-1fbd-4361-b005-3d3d10817d16" name="Gala Appleby">
-   <property name="Number" value="021" />
+   <property name="Number" value="PR21" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Refined Farmer" />
@@ -545,7 +545,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="ad066572-9e76-4b8e-836f-0f461b96ba0f" name="Apple Cobbler">
-   <property name="Number" value="022" />
+   <property name="Number" value="PR22" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Headstrong" />
@@ -554,8 +554,8 @@
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Stubborn." />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Stubborn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -565,7 +565,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="0b979623-7d40-4ca3-833c-656c4488ac49" name="Applejack">
-   <property name="Number" value="023" />
+   <property name="Number" value="PR23" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Plant Leader" />
@@ -585,7 +585,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="e0146473-e864-4cc3-9464-8f1244b6b635" name="Applejack">
-   <property name="Number" value="024" />
+   <property name="Number" value="PR24" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Barn Raiser" />
@@ -605,7 +605,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="733d5c75-d276-4224-b5c6-9551a4001979" name="Auntie Applesauce">
-   <property name="Number" value="025" />
+   <property name="Number" value="PR25" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Gum Flapper" />
@@ -625,7 +625,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="10f58c29-07e0-41d6-b231-8a6ab96edc17" name="Cherry Jubilee">
-   <property name="Number" value="026" />
+   <property name="Number" value="PR26" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Queen of the Hill" />
@@ -645,7 +645,7 @@
    <property name="Rarity" value="F" />
   </card>
   <card id="67a50d37-382b-42ad-a66c-0c2bbf78a226" name="Coco Crusoe">
-   <property name="Number" value="027" />
+   <property name="Number" value="PR27" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Thick Skinned" />
@@ -655,7 +655,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you reveal a Troublemaker at this card's Problem, an opponent discards two random cards." />
+   <property name="Text" value="When you uncover a Troublemaker at this card's Problem, an opponent discards 2 random cards." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -665,7 +665,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="12af9430-0785-4e63-8070-d16b66777c65" name="Granny Smith">
-   <property name="Number" value="028" />
+   <property name="Number" value="PR28" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Apple Elder" />
@@ -675,7 +675,7 @@
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony, Elder" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card, you may move a Resource from one Friend to another." />
+   <property name="Text" value="When you play this card, you may reattach a Resource from one Friend to another." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -685,7 +685,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="8eb51ca3-631a-44a4-be8b-184786c27da9" name="Igneous Rock">
-   <property name="Number" value="029" />
+   <property name="Number" value="PR29" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Pebble Pusher" />
@@ -705,7 +705,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="0b47601c-cd7e-46d4-b8c5-041d1539d7b5" name="Drill Bit">
-   <property name="Number" value="030" />
+   <property name="Number" value="PR30" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Destruction Worker" />
@@ -725,7 +725,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="f5448e80-549b-433b-9e75-ec0563e1025e" name="Full Steam">
-   <property name="Number" value="031" />
+   <property name="Number" value="PR31" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Smoke Stacked" />
@@ -745,7 +745,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="35226b49-62af-43a7-8cc0-51b6d547dfb1" name="Silver Spanner">
-   <property name="Number" value="032" />
+   <property name="Number" value="PR32" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Nuts for Bolts" />
@@ -755,7 +755,7 @@
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: When one of your Resources is dismissed, you may dismiss this card to play that Resource from your discard pile for free." />
+   <property name="Text" value="Reaction: When one of your Resources is dismissed, you may dismiss this card. If you do, play that Resource from your discard pile for free." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -765,7 +765,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="892c1777-8992-4c37-ad29-11aac71565ea" name="Red Gala">
-   <property name="Number" value="033" />
+   <property name="Number" value="PR33" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Favorite Cousin" />
@@ -785,7 +785,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="ae3aba09-6025-4ea2-8bf4-6605c2ad7ff4" name="Sunny Smiles">
-   <property name="Number" value="034" />
+   <property name="Number" value="PR34" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Iconic Friend" />
@@ -805,7 +805,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="db3198c7-0fc3-46a0-974d-895161782c42" name="Night Watch">
-   <property name="Number" value="035" />
+   <property name="Number" value="PR35" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Vigilant Patrol" />
@@ -825,7 +825,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="ed4b8833-5d8e-4434-8d4b-def5837e5fee" name="Apple Brown Betty">
-   <property name="Number" value="036" />
+   <property name="Number" value="PR36" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Pastry Chef" />
@@ -845,7 +845,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="c11de2e1-d83b-45b5-9d14-555ec552e6e6" name="Berry Dreams">
-   <property name="Number" value="037" />
+   <property name="Number" value="PR37" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Pom-Pom Pony" />
@@ -865,7 +865,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="7b846d4a-b904-481a-9e51-2a321cf9a097" name="Big Top">
-   <property name="Number" value="038" />
+   <property name="Number" value="PR38" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Silly Pony" />
@@ -882,10 +882,10 @@
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="C" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="94de3f47-ba94-489a-9296-fa52e62c4f19" name="Charged Up">
-   <property name="Number" value="039" />
+   <property name="Number" value="PR39" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Energizer Pony" />
@@ -895,7 +895,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you move this card to a Problem, you may look at the top 2 cards of that Problem's deckand put them back in any order." />
+   <property name="Text" value="When you move this card to a Problem, you may look at the top 2 cards of that Problem's deck and put them back in any order." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -905,7 +905,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="62237676-b22e-4b14-8ebb-2f6fa3ce46df" name="Dance Fever">
-   <property name="Number" value="040" />
+   <property name="Number" value="PR40" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Disco King" />
@@ -914,8 +914,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Random" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Random." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -925,7 +925,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="75c78bef-8f7b-4261-a8d0-a79db82b585f" name="Lucky Streak">
-   <property name="Number" value="041" />
+   <property name="Number" value="PR41" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="One in a Million" />
@@ -935,7 +935,7 @@
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card, you may uncover a face-down Troublemaker.  Main Phase: Exhaust this card to look at a face-down Troublemaker." />
+   <property name="Text" value="When you play this card, you may uncover a face-down Troublemaker.&#10;Main Phase: Exhaust this card to look at a face-down Troublemaker." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -945,7 +945,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="c470fd94-4e06-4508-aa07-3e42d3b194f9" name="Flitter">
-   <property name="Number" value="042" />
+   <property name="Number" value="PR42" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Ribbon Wielder" />
@@ -955,7 +955,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When involved in a Troublemaker faceoff, this card gets +1 power." />
+   <property name="Text" value="While involved in a Troublemaker faceoff, this card gets +1 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -965,7 +965,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="58c52f1a-0263-4415-81cb-77544343de7a" name="Goldengrape">
-   <property name="Number" value="043" />
+   <property name="Number" value="PR43" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Popular Punster" />
@@ -975,7 +975,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you win a Problem faceoff involving this card, you may search your deck for a Friend. Reveal it, put it into your hand, and shuffle your deck." />
+   <property name="Text" value="When you win a Problem faceoff involving this card, you may search your deck for a Friend, reveal it, put it into your hand, and shuffle your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -985,7 +985,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="d1d1e799-c57b-4da7-8154-81b0b82edb16" name="High Spirits">
-   <property name="Number" value="044" />
+   <property name="Number" value="PR44" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Life Enthusiast" />
@@ -1005,10 +1005,10 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="565034aa-2540-4a36-9056-3189fb14209d" name="Pinkie Pie">
-   <property name="Number" value="045" />
+   <property name="Number" value="PR45" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
-   <property name="Subname" value="Pinkie 'Responsibility' Pie" />
+   <property name="Subname" value='Pinkie "Responsibility" Pie' />
    <property name="Power" value="2" />
    <property name="Cost" value="4" />
    <property name="PlayRequiredPower" value="2" />
@@ -1025,7 +1025,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="94a6378d-a98a-47c2-bedd-c7f43bcd5881" name="Pinkie Pie">
-   <property name="Number" value="046" />
+   <property name="Number" value="PR46" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Ice Cutter" />
@@ -1034,7 +1034,7 @@
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Random" />
+   <property name="Keywords" value="Random." />
    <property name="Text" value="When your opponent confronts this card's Problem, draw a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1045,7 +1045,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="81252740-83ac-4fd3-a30a-ffda0c359cbe" name="Pinprick">
-   <property name="Number" value="047" />
+   <property name="Number" value="PR47" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Pop Star" />
@@ -1065,7 +1065,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="870fafc3-f161-4dd6-b5d1-0c145f724837" name="Ol' Salt">
-   <property name="Number" value="048" />
+   <property name="Number" value="PR48" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Salt Blocked" />
@@ -1075,7 +1075,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Earth Pony, Elder" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Your opponent needs +1 [Any] to confront this card's Problem." />
+   <property name="Text" value="Your opponent needs +1 power to confront this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1084,8 +1084,8 @@
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="U" />
   </card>
-  <card id="96f0920d-42a1-403c-a75c-b48087353b33" name="Snips and Snails">
-   <property name="Number" value="049" />
+  <card id="96f0920d-42a1-403c-a75c-b48087353b33" name="Snips &amp; Snails">
+   <property name="Number" value="PR49" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Dynamic Duo" />
@@ -1095,7 +1095,7 @@
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn, Foal" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Your opponent needs +1 [Any] to confront this card's Problem." />
+   <property name="Text" value="Your opponent needs +1 power to confront this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1105,7 +1105,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="8295c638-635c-4272-8bcf-58e901ca898c" name="Surprise">
-   <property name="Number" value="050" />
+   <property name="Number" value="PR50" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Party Pegasus" />
@@ -1125,7 +1125,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="04e39fe7-8a12-42b9-b891-65e133e6f515" name="Apple Stars">
-   <property name="Number" value="051" />
+   <property name="Number" value="PR51" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Fruit Prodigy" />
@@ -1134,8 +1134,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Studious." />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Studious." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1145,7 +1145,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="619c1a9c-9048-438d-b610-60bd93a60587" name="Professor Neigh">
-   <property name="Number" value="052" />
+   <property name="Number" value="PR52" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Algebraic!" />
@@ -1155,7 +1155,7 @@
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="While at a problem with a Report Resource, this card gets +1 power." />
+   <property name="Text" value="While at a Problem with a Report Resource, this card gets +1 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1165,7 +1165,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="21c57a8f-bb39-4588-989e-8540ba2f5120" name="Bright Bulb">
-   <property name="Number" value="053" />
+   <property name="Number" value="PR53" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Seasoned Strategist" />
@@ -1175,7 +1175,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: When an opponent's character is played to this card's Problem, you may exhaust this card.  If you do, move that character." />
+   <property name="Text" value="Reaction: When an opponent's character is played to this card's Problem, you may exhaust this card. If you do, move that character." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1185,7 +1185,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="7e24094f-ffbc-447d-a68d-59920b6e870f" name="Comet Tail">
-   <property name="Number" value="054" />
+   <property name="Number" value="PR54" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Hale Bopper" />
@@ -1205,7 +1205,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="648ac353-332d-45e4-9e3f-0503da86f030" name="Mint Jewelup">
-   <property name="Number" value="055" />
+   <property name="Number" value="PR55" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="A Cut Above" />
@@ -1214,8 +1214,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Studious" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Studious." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1225,7 +1225,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="5bef172e-2803-4400-bfe7-67c0c666980d" name="Gyro">
-   <property name="Number" value="056" />
+   <property name="Number" value="PR56" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Poindexter" />
@@ -1235,7 +1235,7 @@
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card, search your deck for an Event. Reveal it, put it into your hand, and shuffle your deck." />
+   <property name="Text" value="When you play this card, you may search your deck for an Event, reveal it, put it into your hand, and shuffle your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1245,7 +1245,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="20ad51f7-3ce6-4085-8eba-ef8643d6ae1e" name="Lemony Gem">
-   <property name="Number" value="057" />
+   <property name="Number" value="PR57" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Sour Grapes" />
@@ -1255,7 +1255,7 @@
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you move this card to a Problem you may move an opponent's character at that Problem to another Problem." />
+   <property name="Text" value="When you move this card to a Problem, you may move an opponent's character at that Problem to another Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1265,7 +1265,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="2a3eb827-36a0-48de-b336-ef31d2a12b0d" name="Mayor Mare">
-   <property name="Number" value="058" />
+   <property name="Number" value="PR58" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Elected Official" />
@@ -1275,7 +1275,7 @@
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Pay 3 to move an opponent's character." />
+   <property name="Text" value="Main Phase: Pay 3AT to move an opponent's character." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1285,7 +1285,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="720c5688-a66b-4b71-9bce-4551b94a39c3" name="Rare Find">
-   <property name="Number" value="059" />
+   <property name="Number" value="PR59" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="A Real Gem" />
@@ -1305,7 +1305,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="0814999a-9f07-4227-bb73-49b245826b07" name="Blue Moon">
-   <property name="Number" value="060" />
+   <property name="Number" value="PR60" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Ol' Blue Eyes" />
@@ -1325,10 +1325,10 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="10eaedc2-7bbf-4508-b79c-6aafb10d8ad6" name="Spring Forward">
-   <property name="Number" value="061" />
+   <property name="Number" value="PR61" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
-   <property name="Subname" value="Companionable FIlly" />
+   <property name="Subname" value="Companionable Filly" />
    <property name="Power" value="2" />
    <property name="Cost" value="3" />
    <property name="PlayRequiredPower" value="3" />
@@ -1345,7 +1345,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="25a26431-521b-4b3f-b865-479dc86c4083" name="Sunny Rays">
-   <property name="Number" value="062" />
+   <property name="Number" value="PR62" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="One Bright Mare" />
@@ -1355,7 +1355,7 @@
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card, look at the top 2 cards of your deck and put them back in any order" />
+   <property name="Text" value="When you play this card, you may look at the top 2 cards of your deck and put them back in any order." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1365,10 +1365,10 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="931e27f3-02a9-44d6-941c-64662e1290a8" name="Lady Justice">
-   <property name="Number" value="063" />
+   <property name="Number" value="PR63" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
-   <property name="Subname" value="Judge and Jury" />
+   <property name="Subname" value="Judge &amp; Jury" />
    <property name="Power" value="3" />
    <property name="Cost" value="4" />
    <property name="PlayRequiredPower" value="" />
@@ -1385,7 +1385,7 @@
    <property name="Rarity" value="F" />
   </card>
   <card id="13f34928-2ea5-4e76-9e8a-bde67b7d3fb3" name="Twilight Sparkle">
-   <property name="Number" value="064" />
+   <property name="Number" value="PR64" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="All-Team Organizer" />
@@ -1395,7 +1395,7 @@
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card to gain 1 until end of the phase." />
+   <property name="Text" value="Main Phase: Exhaust this card to gain 1AT until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1405,7 +1405,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="de169691-ed6b-4356-a7c7-7e6cfd85e8ab" name="Action Shot">
-   <property name="Number" value="065" />
+   <property name="Number" value="PR65" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Shutterbug" />
@@ -1425,7 +1425,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="f3172f7a-e7ee-472d-bd77-b464c047aeb8" name="Big Shot">
-   <property name="Number" value="066" />
+   <property name="Number" value="PR66" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Wildlife Photographer" />
@@ -1435,7 +1435,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When a Troublemaker at this card's Problem is revealed, you may exhaust this card to score a point." />
+   <property name="Text" value="When a Troublemaker at this card's Problem is uncovered, you may exhaust this card to score a point." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1445,7 +1445,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="48c30760-383e-47bf-b5db-95833d0ad967" name="Featherweight">
-   <property name="Number" value="067" />
+   <property name="Number" value="PR67" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Editor-in-Chief" />
@@ -1455,7 +1455,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Pegasus, Foal" />
    <property name="Keywords" value="" />
-   <property name="Text" value="During Problem faceoffs involving this card, you opponent flips an additional card but ignores one of the flipped cards with the highest power." />
+   <property name="Text" value="During Problem faceoffs involving this card, your opponent flips an additional card.&#10;During Problem faceoffs involving this card, your opponent ignores one of their flipped cards with the highest power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1465,7 +1465,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="4798fa26-96e0-4665-840c-d66ffe6b4c1c" name="Fiddly Faddle">
-   <property name="Number" value="068" />
+   <property name="Number" value="PR68" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Country Twang" />
@@ -1475,7 +1475,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card, look at the top two cards of your deck and put them back in any order." />
+   <property name="Text" value="When you play this card, you may look at the top 2 cards of your opponent's deck and put them back in any order." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1485,7 +1485,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="4c342179-be44-45a9-94ad-c77f3c2e6b47" name="Eff Stop">
-   <property name="Number" value="069" />
+   <property name="Number" value="PR69" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Muckraker" />
@@ -1495,7 +1495,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to search your discard pile for an Event and put it into your hand." />
+   <property name="Text" value="Main Phase: Exhaust this card and pay 1AT to search your discard pile for an Event and put it into your hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1505,7 +1505,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="6b0dac67-8fe0-441d-b4cf-02700addcf9f" name="Vidala Swoon">
-   <property name="Number" value="070" />
+   <property name="Number" value="PR70" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Mane Manager" />
@@ -1515,7 +1515,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to search your discard pile for a Friend and put it into your hand." />
+   <property name="Text" value="Main Phase: Exhaust this card and pay 1AT to search your discard pile for a Friend and put it into your hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1525,7 +1525,7 @@
    <property name="Rarity" value="F" />
   </card>
   <card id="4c00ffdb-29fb-4fa2-8e04-301f8f5b8e70" name="Hoity Toity">
-   <property name="Number" value="071" />
+   <property name="Number" value="PR71" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Vogue Authority" />
@@ -1534,8 +1534,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Inspired." />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Inspired." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1545,7 +1545,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="003dfc53-90d4-4935-95ae-362225f4bb1d" name="Savoir Fare">
-   <property name="Number" value="072" />
+   <property name="Number" value="PR72" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Snooty Server" />
@@ -1565,7 +1565,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="77d5d1db-da82-4284-82ef-246392b44044" name="Pearly Stitch">
-   <property name="Number" value="073" />
+   <property name="Number" value="PR73" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Crotchety Crocheter" />
@@ -1575,7 +1575,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony, Elder" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Your opponent's cards can't move this card." />
+   <property name="Text" value="Your opponents can't move this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1585,7 +1585,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="d9e6bacb-388f-4323-873c-e16e9bef6ad8" name="Lotus Blossom">
-   <property name="Number" value="074" />
+   <property name="Number" value="PR74" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Sauna Expert" />
@@ -1605,7 +1605,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="9cebb3dc-54af-4dde-a792-61f1a95c2ed2" name="Rising Star">
-   <property name="Number" value="075" />
+   <property name="Number" value="PR75" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="In the Spotlight" />
@@ -1615,7 +1615,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card to reveal a Troublemaker at its Problem." />
+   <property name="Text" value="Main Phase: Exhaust this card to uncover a Troublemaker at its Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1625,7 +1625,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="28fe67de-d8d6-47de-8f41-b4a8f772fe71" name="Noteworthy">
-   <property name="Number" value="076" />
+   <property name="Number" value="PR76" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Humdinger" />
@@ -1645,7 +1645,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="349c9be3-873b-4193-8359-53dad26ed6e2" name="Rarity">
-   <property name="Number" value="077" />
+   <property name="Number" value="PR77" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Nest Weaver" />
@@ -1665,7 +1665,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="2dfb36bc-a296-42b2-ba23-c9bb32a3c24b" name="Royal Riff">
-   <property name="Number" value="078" />
+   <property name="Number" value="PR78" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Songster" />
@@ -1674,8 +1674,8 @@
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Inspired." />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Inspired." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1685,7 +1685,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="ea6d0440-e9de-4889-a578-3f094b136e3d" name="Sugar Twist">
-   <property name="Number" value="079" />
+   <property name="Number" value="PR79" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Twister Sister" />
@@ -1705,7 +1705,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="ca44c784-bac3-42af-aad0-5036fd83a2d5" name="Amethyst Star">
-   <property name="Number" value="080" />
+   <property name="Number" value="PR80" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Animal Leader" />
@@ -1714,8 +1714,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Caretaker" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Caretaker." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1725,7 +1725,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="1c0a77ea-95dc-4ab1-90d1-9a182930df23" name="Blue Jay">
-   <property name="Number" value="081" />
+   <property name="Number" value="PR81" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Warbler" />
@@ -1745,17 +1745,17 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="52c3da72-778b-43ff-90f0-63a59b6fae88" name="Falcon">
-   <property name="Number" value="082" />
+   <property name="Number" value="PR82" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
-   <property name="Subname" value="Fast and Furious" />
+   <property name="Subname" value="Fast &amp; Furious" />
    <property name="Power" value="1" />
    <property name="Cost" value="1" />
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Critter" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you move this card to a Problem, you may move one of your [Critter] Friends to that Problem for free." />
+   <property name="Text" value="When you move this card to a Problem, you may move one of your Critter Friends to that Problem for free." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1765,17 +1765,17 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="68fc8e5f-4273-464d-8653-56076fc790d1" name="Fluttershy">
-   <property name="Number" value="083" />
+   <property name="Number" value="PR83" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
-   <property name="Subname" value="Guidance Councilor" />
+   <property name="Subname" value="Guidance Counselor" />
    <property name="Power" value="3" />
    <property name="Cost" value="3" />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: When an opponent receives at least 1, you may exhaust this card. If you do, that opponent loses 1." />
+   <property name="Text" value="Reaction: When an opponent receives at least 1AT, you may exhaust this card. If you do, that opponent loses 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1785,7 +1785,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="53d8fd18-6407-4dee-94b1-61a00cf8de68" name="Fluttershy">
-   <property name="Number" value="084" />
+   <property name="Number" value="PR84" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Animal Team" />
@@ -1794,8 +1794,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Caretaker" />
-   <property name="Text" value="When you play this card, the cost of your next [Kindness] Friend is reduced by 1." />
+   <property name="Keywords" value="Caretaker." />
+   <property name="Text" value="When you play this card, the cost of your next [Kindness] Friend this turn is reduced by 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1805,7 +1805,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="6003a6a8-f078-464b-a80b-ee65c3b128a4" name="Forest Owl">
-   <property name="Number" value="085" />
+   <property name="Number" value="PR85" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Novice Assistant" />
@@ -1825,7 +1825,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="b8a568c7-b045-4322-a484-3802ebdfffab" name="House Mouse">
-   <property name="Number" value="086" />
+   <property name="Number" value="PR86" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Little Pipsqueak" />
@@ -1845,7 +1845,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="b9ae30a0-7ed0-439e-8e59-a1c6be28ef8b" name="Hummingway">
-   <property name="Number" value="087" />
+   <property name="Number" value="PR87" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Fine Feathered Friend" />
@@ -1855,7 +1855,7 @@
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Critter" />
    <property name="Keywords" value="" />
-   <property name="Text" value="During Troublemaker faceoffs involving this card and at least two of your other [Critter] Friends, flip an additional card." />
+   <property name="Text" value="During Troublemaker faceoffs involving this card and at least 2 of your other Critter Friends, flip an additional card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1865,7 +1865,7 @@
    <property name="Rarity" value="F" />
   </card>
   <card id="b2190c97-7ba2-4568-9f1b-35fe56b32d8e" name="Lilac Links">
-   <property name="Number" value="088" />
+   <property name="Number" value="PR88" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Superstitious" />
@@ -1875,7 +1875,7 @@
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Problem Faceoff: Exhaust this card to choose a Friend with a Resource on it involved in the faceoff. That Friend gets -5 power until the end of the faceoff." />
+   <property name="Text" value="Problem Faceoff: Exhaust this card and choose a Friend involved in the faceoff with a Resource attached to it to give that Friend -5 power until the end of the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1885,7 +1885,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="4172fe65-9df7-4d73-99c2-46ecdab6eb50" name="Mane Cureall">
-   <property name="Number" value="089" />
+   <property name="Number" value="PR89" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Veteran Vet" />
@@ -1894,8 +1894,8 @@
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Caretaker" />
-   <property name="Text" value="When you play this card to a Problem, you may move one of your [Critter] Friends to the same Problem for free." />
+   <property name="Keywords" value="Caretaker." />
+   <property name="Text" value="When you play this card to a Problem, you may move one of your Critter Friends to the same Problem for free." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1905,7 +1905,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="36b888bb-6e12-4e61-aa43-c43a95aa8c9f" name="Mr. Beaverton Beaverteeth">
-   <property name="Number" value="090" />
+   <property name="Number" value="PR90" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Dam Builder" />
@@ -1925,7 +1925,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="b18bd2cc-5f12-4c0e-89a5-07b97b41ea1c" name="Mr. Breezy">
-   <property name="Number" value="091" />
+   <property name="Number" value="PR91" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Fan Fan" />
@@ -1935,7 +1935,7 @@
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card, an opponent loses 1." />
+   <property name="Text" value="When you play this card, an opponent loses 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1945,7 +1945,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="398e0a29-722f-4258-9173-87264a59de2b" name="Opalescence">
-   <property name="Number" value="092" />
+   <property name="Number" value="PR92" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Curtain Shredder" />
@@ -1965,7 +1965,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="df0bc647-30c6-40a3-9d4c-b3c4d108ff9b" name="Sea Swirl">
-   <property name="Number" value="093" />
+   <property name="Number" value="PR93" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Porpoiseful" />
@@ -1975,7 +1975,7 @@
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card at a Problem to move up to three of your [Critter] Friends to that Problem." />
+   <property name="Text" value="Main Phase: Exhaust this card at a Problem to move up to 3 of your Critter Friends to that Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1985,7 +1985,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="da738623-5739-43c8-beeb-3014d7b835a6" name="Winona">
-   <property name="Number" value="094" />
+   <property name="Number" value="PR94" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="On the Scent" />
@@ -1995,7 +1995,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Critter" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card to look at a face-down troublemaker at its Problem." />
+   <property name="Text" value="Main Phase: Exhaust this card to look at a face-down Troublemaker at its Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2005,7 +2005,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="e085f06d-becd-4268-8065-8d6af9633cdd" name="Spread Your Wings">
-   <property name="Number" value="095" />
+   <property name="Number" value="PR95" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2025,7 +2025,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="d919632e-5123-4aef-a624-fe2adf7b6367" name="Getting Hooves Dirty">
-   <property name="Number" value="096" />
+   <property name="Number" value="PR96" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2042,10 +2042,10 @@
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="C" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="9d065d26-842b-4c8f-80ff-809b350f84ae" name="Dig Deep">
-   <property name="Number" value="097" />
+   <property name="Number" value="PR97" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2055,17 +2055,17 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Choose a [Generosity] or [Loyalty] character. That character gets +1 [Generosity] and +1 [Loyalty] until the end of the phase." />
+   <property name="Text" value="Main Phase: Choose a [Loyalty] or [Generosity] character. That character gets +1 [Loyalty] and +1 [Generosity] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="C" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="32de64d0-4da4-4abd-a860-8db3f621c790" name="Apples and Oranges">
-   <property name="Number" value="098" />
+   <property name="Number" value="PR98" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2085,7 +2085,7 @@
    <property name="Rarity" value="F" />
   </card>
   <card id="7280bcab-240b-4039-bba6-41d2dbabe054" name="Royal Guidance">
-   <property name="Number" value="099" />
+   <property name="Number" value="PR99" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2105,7 +2105,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="8a98e8f9-f337-4c61-8131-7eabd1939486" name="Sweet and Kind">
-   <property name="Number" value="100" />
+   <property name="Number" value="PR100" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2115,17 +2115,17 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Choose a [Kindness] or [Honesty] character. That character gets +1 [Kindness] and +1 [Honesty] until the end of the phase." />
+   <property name="Text" value="Main Phase: Choose a [Honesty] or [Kindness] character. That character gets +1 [Honesty] and +1 [Kindness] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="C" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="83696652-dad4-4459-a44a-b9b8bee11ebe" name="Good Hustle">
-   <property name="Number" value="101" />
+   <property name="Number" value="PR101" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2135,7 +2135,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: Choose a [Pegasus] character. That character gets +2 power until the end of the faceoff." />
+   <property name="Text" value="Faceoff: Choose a Pegasus character. That character gets +2 power until the end of the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2145,7 +2145,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="771cfb89-5312-4d2f-9231-a723c1a93bc4" name="A Bully and a Beast">
-   <property name="Number" value="102" />
+   <property name="Number" value="PR102" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2155,7 +2155,7 @@
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Troublemaker Faceoff Reaction: Play after you flip a card for the Troublemaker. Ignore that card's power and flip a new card." />
+   <property name="Text" value="Reaction: After you flip a card during a Troublemaker faceoff while your opponent is challenging a Troublemaker, ignore that card and flip another card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2165,7 +2165,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="85fa9221-a2cf-4c3c-8de1-87ec17e96f19" name="A Touch of Refinement">
-   <property name="Number" value="103" />
+   <property name="Number" value="PR103" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2185,7 +2185,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="4f64676b-f4b0-4486-a425-db9c29b6a300" name="A Vision of the Future">
-   <property name="Number" value="104" />
+   <property name="Number" value="PR104" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2205,7 +2205,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="7bcb195e-973c-4752-9b8e-a5dde6d91a86" name="Assertiveness Training">
-   <property name="Number" value="105" />
+   <property name="Number" value="PR105" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2215,7 +2215,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: If you have Rarity or Pinkie Pie involved in this faceoff, flip an additional card. If you have Rarity and Pinkie Pie involved in this faceoff, flip two additional cards instead." />
+   <property name="Text" value="Faceoff: If you have Rarity or Pinkie Pie involved in this faceoff, flip an additional card. If you have Rarity and Pinkie Pie involved in this faceoff, flip 2 additional cards instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2225,7 +2225,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="2f58dace-f575-41fd-a34d-a2c6cb980c86" name="Back Where You Began">
-   <property name="Number" value="106" />
+   <property name="Number" value="PR106" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2244,8 +2244,8 @@
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="R" />
   </card>
-  <card id="4a6b51eb-9301-4423-87a3-8d99cedc7589" name="Creme de la Creme">
-   <property name="Number" value="107" />
+  <card id="4a6b51eb-9301-4423-87a3-8d99cedc7589" name="Crème de la Crème">
+   <property name="Number" value="PR107" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2255,7 +2255,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Problem Faceoff Reaction: Play when you win a Problem faceoff by at least five power. Score an additional point." />
+   <property name="Text" value="Problem Faceoff Reaction: Play when you win a Problem faceoff by at least 5 power. Score an additional point." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2265,7 +2265,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="230b4174-38f5-485b-b34a-8bb23bbeaafe" name="Critter Cavalry">
-   <property name="Number" value="108" />
+   <property name="Number" value="PR108" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2285,7 +2285,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="64ba211b-fd3d-4da5-b2d0-bf006cae5ce6" name="Double-check the Checklist">
-   <property name="Number" value="109" />
+   <property name="Number" value="PR109" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2305,7 +2305,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="7ecd8cef-96a3-446f-bcd5-bfc0e5dc4eb2" name="Downright Dangerous">
-   <property name="Number" value="110" />
+   <property name="Number" value="PR110" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2315,7 +2315,7 @@
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Choose an opponent's Friend to get -2 power until the end of the turn. If it has zero power or less, dismiss it." />
+   <property name="Text" value="Main Phase: Choose an opponent's Friend to get -2 power until the end of the turn. If it has 0 power or less, dismiss it." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2325,7 +2325,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="c86d6b85-1f6a-4bfe-8858-e10b55e475b7" name="Duck and Cover">
-   <property name="Number" value="111" />
+   <property name="Number" value="PR111" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2335,7 +2335,7 @@
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff Reaction: Play when you flip a card. Ignore that card's power and flip a new card." />
+   <property name="Text" value="Reaction: After you flip a card during a faceoff, ignore that card and flip a new card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2345,7 +2345,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="65a7fadb-ab50-4409-9238-5898bd9f26ca" name="Eeyup">
-   <property name="Number" value="112" />
+   <property name="Number" value="PR112" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2365,7 +2365,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="b9ca3f45-6db8-431a-9b7b-63e04a9b0f63" name="Here's Your Invitation!">
-   <property name="Number" value="113" />
+   <property name="Number" value="PR113" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2375,7 +2375,7 @@
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Dismiss an opponent's Friend with one power or less." />
+   <property name="Text" value="Main Phase: Dismiss an opponent's Friend with 1 power or less." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2385,7 +2385,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="20260ea9-509e-4512-a181-7baf3b8f262e" name="Let's Get This Party Started">
-   <property name="Number" value="114" />
+   <property name="Number" value="PR114" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2395,7 +2395,7 @@
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Draw three cards." />
+   <property name="Text" value="Main Phase: Draw 3 cards." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2405,7 +2405,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="98b1e589-267a-40b2-ba66-d0b3fa6f4edb" name="Fears Must be Faced">
-   <property name="Number" value="115" />
+   <property name="Number" value="PR115" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2415,7 +2415,7 @@
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Troublemaker Phase: Choose up to two of your characters at home. Move each of them to a different Problem." />
+   <property name="Text" value="Troublemaker Phase: Choose up to 2 of your characters at home. Move each of them to a different Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2425,7 +2425,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="79cb7097-33b9-4dfe-841e-f6c87e3d6787" name="Nurture With Knowledge">
-   <property name="Number" value="116" />
+   <property name="Number" value="PR116" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2445,7 +2445,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="0268b4ff-18f4-4c31-a691-45ee238869ca" name="Gotta Go Fast">
-   <property name="Number" value="117" />
+   <property name="Number" value="PR117" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2465,7 +2465,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="913c1c74-25b4-442f-ae59-c71a7e3f76e6" name="Stand Still!">
-   <property name="Number" value="118" />
+   <property name="Number" value="PR118" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2475,7 +2475,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: Play after an opponent's character has just been moved. Return that character to its original location." />
+   <property name="Text" value="Reaction: Play after an opponent's character has just been moved. Send that character to its previous area." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2484,8 +2484,8 @@
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="R" />
   </card>
-  <card id="23b6ee73-a9a5-4210-9cf3-7f7c81f0dac8" name="Straighten Up and Fly Right">
-   <property name="Number" value="119" />
+  <card id="23b6ee73-a9a5-4210-9cf3-7f7c81f0dac8" name="Straighten Up &amp; Fly Right">
+   <property name="Number" value="PR119" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2495,7 +2495,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: If you have Twilight Sparkle or Fluttershy involved in this faceoff, flip an additional card. If you have Twilight Sparkle and Fluttershy involved in this faceoff, flip two additional cards instead." />
+   <property name="Text" value="Faceoff: If you have Twilight Sparkle or Fluttershy involved in this faceoff, flip an additional card. If you have Twilight Sparkle and Fluttershy involved in this faceoff, flip 2 additional cards instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2504,8 +2504,8 @@
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="R" />
   </card>
-  <card id="033dae42-a23c-437e-9d7f-21394360303b" name="Swing into Action">
-   <property name="Number" value="120" />
+  <card id="033dae42-a23c-437e-9d7f-21394360303b" name="Swing Into Action">
+   <property name="Number" value="PR120" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2525,7 +2525,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="698e9148-f964-4662-8050-7a84257f55a3" name="Team Effort">
-   <property name="Number" value="121" />
+   <property name="Number" value="PR121" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2535,7 +2535,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: If you have Twilight Sparkle or Applejack involved in this faceoff, flip an additional card. If you have Twilight Sparkle and Applejack involved in this faceoff, flip two additional cards instead." />
+   <property name="Text" value="Faceoff: If you have Applejack or Twilight Sparkle involved in this faceoff, flip an additional card. If you have Applejack and Twilight Sparkle involved in this faceoff, flip 2 additional cards instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2545,7 +2545,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="7e842891-a6ec-473d-8d91-0939f89d7b59" name="The Big Guns">
-   <property name="Number" value="122" />
+   <property name="Number" value="PR122" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2555,7 +2555,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: If you have Rainbow Dash or Pinkie Pie involved in this faceoff, flip an additional card. If you have Rainbow Dash and Pinkie Pie involved in this faceoff, flip two additional cards instead." />
+   <property name="Text" value="Faceoff: If you have Rainbow Dash or Pinkie Pie involved in this faceoff, flip an additional card. If you have Rainbow Dash and Pinkie Pie involved in this faceoff, flip 2 additional cards instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2565,7 +2565,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="cf5187b9-e5ff-4ee1-bebc-74c31d441df1" name="The Horror! The Horror!">
-   <property name="Number" value="123" />
+   <property name="Number" value="PR123" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2585,7 +2585,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="cf2d8b0e-98b7-4a2e-914c-076dd4e4d723" name="Spike, Take a Letter">
-   <property name="Number" value="124" />
+   <property name="Number" value="PR124" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2595,7 +2595,7 @@
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Troublemaker Faceoff Reaction: Play when you defeat a Troublemaker, Gain 2." />
+   <property name="Text" value="Troublemaker Faceoff Reaction: Play when you defeat a Troublemaker. Gain 2AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2605,7 +2605,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="c68b2848-34a4-4c7c-8a5e-bada2c8db2a4" name="Undercover Adventure">
-   <property name="Number" value="125" />
+   <property name="Number" value="PR125" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2615,7 +2615,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: If you have Rainbow Dash or Rarity involved in this faceoff, flip an additional card. If you have Rainbow Dash and Rarity involved in this faceoff, flip two additional cards instead." />
+   <property name="Text" value="Faceoff: If you have Rainbow Dash or Rarity involved in this faceoff, flip an additional card. If you have Rainbow Dash and Rarity involved in this faceoff, flip 2 additional cards instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2625,7 +2625,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="56cbe593-79e4-4171-843d-84a9d7f8e589" name="Watch in Awe">
-   <property name="Number" value="126" />
+   <property name="Number" value="PR126" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2645,7 +2645,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="8b61579e-d4eb-4f23-a04d-74b751c4b6b7" name="What Went Wrong?">
-   <property name="Number" value="127" />
+   <property name="Number" value="PR127" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2655,7 +2655,7 @@
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff Reaction: Play after your opponent flips a card. Your opponent ignores that card's power and flips a new card." />
+   <property name="Text" value="Reaction: After your opponent flips a card during a faceoff, your opponent ignores that card and flips another card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2665,7 +2665,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="a3fd7f53-2818-4836-aa14-2c1b28effca4" name="Whoa There Nelly!">
-   <property name="Number" value="128" />
+   <property name="Number" value="PR128" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2685,7 +2685,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="d241019a-7f8f-43c2-8d5d-efbe8dea19f1" name="Working Together">
-   <property name="Number" value="129" />
+   <property name="Number" value="PR129" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2695,7 +2695,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: If you have Applejack or Fluttershy involved in this faceoff, flip an additional card. If you have Applejack and Fluttershy involved in this faceoff, flip two additional cards instead." />
+   <property name="Text" value="Faceoff: If you have Applejack or Fluttershy involved in this faceoff, flip an additional card. If you have Applejack and Fluttershy involved in this faceoff, flip 2 additional cards instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2705,7 +2705,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="a7607786-d6cc-4bad-9df1-70161b888fe2" name="Yay!">
-   <property name="Number" value="130" />
+   <property name="Number" value="PR130" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2725,7 +2725,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="7b9701fe-167b-42a3-b316-787902fe3c1b" name="Assault Cake">
-   <property name="Number" value="131" />
+   <property name="Number" value="PR131" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2733,9 +2733,9 @@
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
-   <property name="Traits" value="" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Faceoff Reaction: When a faceoff begins, you may put this card on the top of your deck." />
+   <property name="Traits" value="Asset" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Faceoff Reaction: When a faceoff begins, you may put this card on the top of your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2745,7 +2745,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="24f1c008-fa29-4abb-bc07-394207b4843f" name="Carousel Boutique">
-   <property name="Number" value="132" />
+   <property name="Number" value="PR132" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2754,8 +2754,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Dismiss this card to search your discard pile for a card and put it into your hand." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Dismiss this card to search your discard pile for a card and put it into your hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2765,7 +2765,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="e9cdf5cd-af69-44d8-b352-efb81842820d" name="Tangled Coiffure">
-   <property name="Number" value="133" />
+   <property name="Number" value="PR133" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2774,8 +2774,8 @@
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on an opponent's Friend." />
-   <property name="Text" value="Your opponent can't move this Friend." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on an opponent's Friend.&#10;Your opponent can't move this Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2785,7 +2785,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="b305a0b7-0f18-4595-9f43-0154414492ff" name="Critter Cuisine">
-   <property name="Number" value="134" />
+   <property name="Number" value="PR134" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2794,8 +2794,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to give each of your [Critter] Friends +1 [Kindness] until the start of your next turn." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and pay 1AT to give each of your Critter Friends +1 [Kindness] until the start of your next turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2805,7 +2805,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="54ab53a2-6050-40f9-9bcb-37471d06c911" name="Fighting for Friendship">
-   <property name="Number" value="135" />
+   <property name="Number" value="PR135" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2814,8 +2814,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Report" />
-   <property name="Keywords" value="Play on a Problem." />
-   <property name="Text" value="Your characters at this Problem each get +1 power during faceoffs." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Problem.&#10;Your characters at this Problem each get +1 power during faceoffs." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2825,7 +2825,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="32242ea3-7e2e-44ca-9e88-f2b9bd9f191d" name="Foal Free Press">
-   <property name="Number" value="136" />
+   <property name="Number" value="PR136" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2834,8 +2834,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="When you uncover a Troublemaker, the next card you play that turn has its cost reduced by 1." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;When you uncover a Troublemaker, the next card you play that turn has its cost reduced by 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2845,7 +2845,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="fd94188b-ec9c-4f7a-b78f-7cf3f2da7ef5" name="Focused Study">
-   <property name="Number" value="137" />
+   <property name="Number" value="PR137" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2854,8 +2854,8 @@
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Report" />
-   <property name="Keywords" value="Play on a Problem." />
-   <property name="Text" value="Your opponent may not play Friends with 2 power or less to this Problem." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Problem.&#10;Your opponent may not play Friends with 2 power or less to this Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2865,7 +2865,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="cbb3ac77-c6bf-4c84-9628-2063f49a09aa" name="Golden Oak Library">
-   <property name="Number" value="138" />
+   <property name="Number" value="PR138" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2874,8 +2874,8 @@
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to reveal the top three cards of your deck. You may put one revealed Event into your hand and all remaining cards on the top of your deck in any order." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and pay 1AT to reveal the top 3 cards of your deck. You may put 1 revealed Event into into your hand and all remaining cards on the top of your deck in any order." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2885,7 +2885,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="054beabb-9a23-4ad9-bbf9-46691397fa03" name="Hard Hat">
-   <property name="Number" value="139" />
+   <property name="Number" value="PR139" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2894,8 +2894,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="The Friend has Stubborn." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;This Friend has Stubborn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2905,7 +2905,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="01612a10-b8ee-40c6-829a-e4d1aac25f08" name="Lead Pony Badge">
-   <property name="Number" value="140" />
+   <property name="Number" value="PR140" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2914,8 +2914,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: choose one of your ready cards. Exhasut this card and that card to ready an exhausted character." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Choose one of your ready cards. Exhaust this card and that card to ready an exhausted character." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2925,7 +2925,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="89490f6f-6eaf-45b4-916b-01d800d20ff4" name="Marvelous Chapeau">
-   <property name="Number" value="141" />
+   <property name="Number" value="PR141" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2934,8 +2934,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="While this Friend is at an opponent's Problem, if you have at least 3 [Generosity] in play, you need one less [Any] to confront that Problem." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;While this Friend is at an opponent's Problem, if you have at least 3 [Generosity] in play, you need -1 power to confront that Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2945,7 +2945,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="0a5b3003-20ad-4376-b8a6-90cdd34064ad" name="Outshine Them All">
-   <property name="Number" value="142" />
+   <property name="Number" value="PR142" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2954,8 +2954,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Report" />
-   <property name="Keywords" value="Play on a Problem." />
-   <property name="Text" value="When you win a faceoff at this Problem, gain 1." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Problem.&#10;When you win a faceoff at this Problem, gain 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2965,7 +2965,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="848903c9-c9d0-4dad-91cb-33ac881ed06a" name="Ridiculous Outfit">
-   <property name="Number" value="143" />
+   <property name="Number" value="PR143" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2974,8 +2974,8 @@
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="While this Friend is at a Problem, your opponent's characters at that Problem each get -1 power during the Score Phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;While this Friend is at a Problem, your opponent's characters at that Problem each get -1 power during the Score Phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2985,7 +2985,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="14a57245-9d28-494d-aac1-9bfdd4087088" name="Rubber Chicken">
-   <property name="Number" value="144" />
+   <property name="Number" value="PR144" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2994,8 +2994,8 @@
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="While this Friend is involved in a Troublemake faceoff, it gets +2 [Laughter]." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;While this Friend is involved in a Troublemaker faceoff, it gets +2 Pink." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3005,7 +3005,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="ee3d4cab-fbc4-419d-bc8b-755ad532597a" name="Sweet Apple Acres">
-   <property name="Number" value="145" />
+   <property name="Number" value="PR145" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3014,8 +3014,8 @@
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to force your opponent to choose and discard a card." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and pay 1AT to force your opponent to choose and discard a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3025,7 +3025,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="9415f572-c704-4cb3-82af-f3be63d91304" name="Picnic Lunch">
-   <property name="Number" value="146" />
+   <property name="Number" value="PR146" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3034,8 +3034,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="While at least 3 of your [Kindness] Friends are at one Problem, flip an additional card during faceoffs at that Problem." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;While at least 3 of your [Kindness] Friends are at one Problem, flip an additional card during faceoffs at that Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3045,7 +3045,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="fcacdfb0-159b-4e5f-8ada-d6938710fb5c" name="The Ponyville Express">
-   <property name="Number" value="147" />
+   <property name="Number" value="PR147" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3054,8 +3054,8 @@
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Reaction: When you defeat a Troublemaker using only [Generosity] characters, dismiss this card to score an additional point." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Reaction: When you defeat a Troublemaker using only [Generosity] characters, dismiss this card to score an additional point." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3065,7 +3065,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="1fa2d8be-1d5e-4bf0-ab97-7b559b395266" name="Too Many Bandages">
-   <property name="Number" value="148" />
+   <property name="Number" value="PR148" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3074,8 +3074,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="This Friend gets -2 power." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;This Friend gets -2 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3085,7 +3085,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="02ca992e-9e58-4127-a94e-eb838bc0a7c1" name="Too Much Pie">
-   <property name="Number" value="149" />
+   <property name="Number" value="PR149" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3094,8 +3094,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="This Friend gets -5 power during the Score Phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;This Friend gets -5 power during the Score Phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3105,7 +3105,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="94420450-73a9-4ed2-820a-083e410eed1a" name="Tricksy Hat">
-   <property name="Number" value="150" />
+   <property name="Number" value="PR150" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3114,8 +3114,8 @@
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to choose an opponent's character at a problem. Move it home." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and pay 1AT to choose an opponent's character at a Problem. Move it home." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3125,7 +3125,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="c0624277-9e0e-40a7-84f2-c2ef3982c931" name="Two Bits">
-   <property name="Number" value="151" />
+   <property name="Number" value="PR151" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3134,8 +3134,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Dismiss this card to reduce the cost of the next card you play this turn by 2." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Dismiss this card to reduce the cost of the next card you play this turn by 2AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3145,7 +3145,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="d156045a-d153-483d-8da1-6cefc6f3d47e" name="Ahuizotl">
-   <property name="Number" value="152" />
+   <property name="Number" value="PR152" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3153,7 +3153,7 @@
    <property name="Cost" value="" />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="" />
+   <property name="Traits" value="Epic" />
    <property name="Keywords" value="Villain." />
    <property name="Text" value="At the end of each player's Troublemaker Phase, that player moves one of their characters home from this card's Problem." />
    <property name="ProblemBonus" value="2" />
@@ -3165,7 +3165,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="652f6fac-3c72-46ad-9b3a-0000a8637755" name="Brown Parasprite">
-   <property name="Number" value="153" />
+   <property name="Number" value="PR153" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3175,7 +3175,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="At the start of your opponent's Troublemaker Phase, they discard a card from the top of their deck." />
+   <property name="Text" value="At the start of your opponent's Troublemaker Phase, they put the top card of their deck into their discard pile." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3185,7 +3185,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="24da7159-c33d-4fd0-89e4-eb757421819f" name="Flam">
-   <property name="Number" value="154" />
+   <property name="Number" value="PR154" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3205,7 +3205,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="cdfb213b-40b8-477e-b34f-fcfa41b6fc70" name="Flim">
-   <property name="Number" value="155" />
+   <property name="Number" value="PR155" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3225,7 +3225,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="679f6dc4-35ae-4fb8-b91c-11e67bb4582b" name="Parasprite Swarm">
-   <property name="Number" value="156" />
+   <property name="Number" value="PR156" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3235,7 +3235,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="At the start of your oppoent's Troublemaker Phase, this card permanently gets +1 power. When this card has eight power, frighten all your opponent's Friends at its Problem and dismiss this card." />
+   <property name="Text" value="At the start of your opponent's Troublemaker Phase, this card permanently gets +1 power. When this card has 8 power, frighten all your opponent's Friends at its Problem and dismiss this card." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3245,7 +3245,7 @@
    <property name="Rarity" value="R" />
   </card>
   <card id="ac0753a2-f8f8-45f4-b8fb-86cdd394ed8e" name="Purple Parasprite">
-   <property name="Number" value="157" />
+   <property name="Number" value="PR157" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3265,7 +3265,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="3f5daace-d085-41fd-b2fa-1a1dff8bbd51" name="Timberwolf">
-   <property name="Number" value="158" />
+   <property name="Number" value="PR158" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3275,7 +3275,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you uncover this card, pay 2 or dismiss it. Your opponent must pay +2 to play a Friend to this card's Problem." />
+   <property name="Text" value="When this card is uncovered, its owner must pay 2AT or dismiss it.&#10;Your opponent must pay +2AT to play a Friend to this card's Problem." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3285,7 +3285,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="89739781-96a8-4d21-a765-6225bd611248" name="Wild Manticore">
-   <property name="Number" value="159" />
+   <property name="Number" value="PR159" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3295,7 +3295,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="During faceoffs against this card, the challenger's opponent flips an additional card." />
+   <property name="Text" value="During faceoffs involving this card, flip an additional card." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3305,7 +3305,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="31b24d0c-564a-4b5c-90a4-723177ac123f" name="Yellow Parasprite">
-   <property name="Number" value="160" />
+   <property name="Number" value="PR160" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3325,7 +3325,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="3d2872f9-bb34-45bd-92d7-a6100d9ebe34" name="A Thorn in His Paw">
-   <property name="Number" value="161" />
+   <property name="Number" value="PR161" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3335,7 +3335,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="Starting Problem." />
-   <property name="Text" value="While a player has at least three [Kindness] Friends at this Problem, that player's opponent must pay +1 to play a Friend here." />
+   <property name="Text" value="While a player has at least 3 [Kindness] Friends at this Problem, that player's opponent must pay +1AT to play a Friend here." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Kindness" />
@@ -3345,7 +3345,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="0760b742-8342-45fa-9e9b-d8f59a462a65" name="Avalanche!">
-   <property name="Number" value="162" />
+   <property name="Number" value="PR162" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3364,8 +3364,8 @@
    <property name="ProblemPlayerElement2Power" value="2" />
    <property name="Rarity" value="C" />
   </card>
-  <card id="28dcd7e2-73fd-4abc-a48f-d01639ec6d96" name="Kitchen au Flambe">
-   <property name="Number" value="163" />
+  <card id="28dcd7e2-73fd-4abc-a48f-d01639ec6d96" name="Kitchen au Flambé">
+   <property name="Number" value="PR163" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3375,7 +3375,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="The first player to confront this Problem may take a Friend with one power from their discard pile and put it in their hand." />
+   <property name="Text" value="The first player to confront this Problem may put a Friend with 1 power from their discard pile into their hand." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Generosity" />
@@ -3385,7 +3385,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="1b6d137a-5bfe-4a2d-9ab8-29bc48d8c8a6" name="Bunny Breakout">
-   <property name="Number" value="164" />
+   <property name="Number" value="PR164" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3405,7 +3405,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="0327df62-c120-4899-b185-1562f0beca9e" name="Bunny Stampede">
-   <property name="Number" value="165" />
+   <property name="Number" value="PR165" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3424,8 +3424,8 @@
    <property name="ProblemPlayerElement2Power" value="2" />
    <property name="Rarity" value="C" />
   </card>
-  <card id="7a85252b-0287-47e2-a9b5-81c752d555b2" name="The Problem with Parasprites">
-   <property name="Number" value="166" />
+  <card id="7a85252b-0287-47e2-a9b5-81c752d555b2" name="The Problem With Parasprites">
+   <property name="Number" value="PR166" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3445,7 +3445,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="8c840c09-2570-4f22-890c-5223f55beb42" name="Clearing Gloomy Skies">
-   <property name="Number" value="167" />
+   <property name="Number" value="PR167" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3455,7 +3455,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Players with at least two [Pegasus] characters at this Problem get +1 total power during faceoffs here." />
+   <property name="Text" value="Players with at least 2 Pegasus characters at this Problem get +1 total power during faceoffs here." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="9" />
    <property name="ProblemPlayerElement1" value="Loyalty" />
@@ -3465,7 +3465,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="5b1ca583-1239-4b31-93f2-2546b9c8c810" name="Cloudbursting">
-   <property name="Number" value="168" />
+   <property name="Number" value="PR168" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3485,7 +3485,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="7d20e6f5-9bb5-45a9-b9a4-add7e1046080" name="Adventures in Foalsitting">
-   <property name="Number" value="169" />
+   <property name="Number" value="PR169" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3505,7 +3505,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="94e8ffa0-badc-4546-a8ba-300ab8145748" name="Emergency Dress Order">
-   <property name="Number" value="170" />
+   <property name="Number" value="PR170" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3525,7 +3525,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="3c3f280b-372c-406b-a0c6-ecea87d803d8" name="795 Wing Power">
-   <property name="Number" value="171" />
+   <property name="Number" value="PR171" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3535,7 +3535,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Resources played on characters here have their costs reduced by 1." />
+   <property name="Text" value="Resources played on characters here have their costs reduced by 1AT." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Loyalty" />
@@ -3545,7 +3545,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="a4a9a5fc-1843-4a30-85aa-04b7ce9d557d" name="Mean Meanie Pants">
-   <property name="Number" value="172" />
+   <property name="Number" value="PR172" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3565,7 +3565,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="d4e04055-1a0b-41c3-b539-19c21e9eaeef" name="Hungry Hungry Caterpillars">
-   <property name="Number" value="173" />
+   <property name="Number" value="PR173" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3584,8 +3584,8 @@
    <property name="ProblemPlayerElement2Power" value="2" />
    <property name="Rarity" value="C" />
   </card>
-  <card id="bb32975a-83f3-48fa-9414-829e0a137ae6" name="I Can Fix it!">
-   <property name="Number" value="174" />
+  <card id="bb32975a-83f3-48fa-9414-829e0a137ae6" name="I Can Fix It!">
+   <property name="Number" value="PR174" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3595,7 +3595,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="Starting Problem." />
-   <property name="Text" value="When a player wins a faceoff here by exactly one power, that player scores and additional point." />
+   <property name="Text" value="When a player wins a faceoff here by exactly 1 power, that player scores an additional point." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
    <property name="ProblemPlayerElement1" value="Generosity" />
@@ -3605,7 +3605,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="3f36b4eb-93c7-4171-b224-6c9c2b8bf294" name="I Need Answers">
-   <property name="Number" value="175" />
+   <property name="Number" value="PR175" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3615,7 +3615,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="During their Main Phase, players may dismiss one of their Friends here to gain 1." />
+   <property name="Text" value="Main Phase: Dismiss one of your Friends here to gain 1AT. Any player may activate this ability." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="6" />
    <property name="ProblemPlayerElement1" value="Magic" />
@@ -3625,7 +3625,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="e8378695-b62d-4789-9ed1-29c5d1ecce1f" name="It's a Twister!">
-   <property name="Number" value="176" />
+   <property name="Number" value="PR176" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3635,7 +3635,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Score Phase: At the beginning of a player's Score Phase, if that player has at least two [Loyalty] characters, that player may ready a card at home." />
+   <property name="Text" value="At the beginning of a player's Score Phase, if that player has at least 2 [Loyalty] characters, that player may ready a card at home." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Loyalty" />
@@ -3644,8 +3644,8 @@
    <property name="ProblemPlayerElement2Power" value="2" />
    <property name="Rarity" value="U" />
   </card>
-  <card id="73e86ebf-7b32-4376-9a56-e915c7551506" name="It's Alive">
-   <property name="Number" value="177" />
+  <card id="73e86ebf-7b32-4376-9a56-e915c7551506" name="It's Alive!">
+   <property name="Number" value="PR177" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3664,8 +3664,8 @@
    <property name="ProblemPlayerElement2Power" value="1" />
    <property name="Rarity" value="U" />
   </card>
-  <card id="7e3e3677-02b1-4717-9207-01a6f3e2dc4e" name="Looking for Trouble">
-   <property name="Number" value="178" />
+  <card id="7e3e3677-02b1-4717-9207-01a6f3e2dc4e" name="Looking For Trouble">
+   <property name="Number" value="PR178" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3685,7 +3685,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="15f2f0d4-44e8-462d-a70c-0afecf8f5078" name="May the Best Pet Win">
-   <property name="Number" value="179" />
+   <property name="Number" value="PR179" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3695,7 +3695,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this problem is played, its owner may search their deck for a [Critter] Friend, reveal it, put it into their hand, and shuffle theird deck." />
+   <property name="Text" value="When this Problem is played, its owner may search their deck for a Critter Friend, reveal it, put it into their hand, and shuffle their deck." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Kindness" />
@@ -3705,7 +3705,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="1209a4e5-860f-4b37-8786-12abb00c5e6d" name="Who is Gabby Gums?">
-   <property name="Number" value="180" />
+   <property name="Number" value="PR180" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3715,7 +3715,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="If there at least three [Generosity] characters at this Problem, characters without [Generosity] can't move away from this Problem." />
+   <property name="Text" value="If there are at least 3 [Generosity] characters at this Problem, characters without [Generosity] can't move away from this Problem." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Generosity" />
@@ -3725,7 +3725,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="18b8cc26-9a15-48d6-8d75-73fab59ad10c" name="Not Enough Pinkie Pies">
-   <property name="Number" value="181" />
+   <property name="Number" value="PR181" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3745,7 +3745,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="f8a0c1aa-3ed1-4b08-8dcf-2fad1648ddcf" name="Monitor EVERYTHING!">
-   <property name="Number" value="182" />
+   <property name="Number" value="PR182" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3755,7 +3755,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="Starting Problem." />
-   <property name="Text" value="Report Resources played on this Problem have their costs reduced by 1." />
+   <property name="Text" value="Report Resources played on this Problem have their costs reduced by 1AT." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Magic" />
@@ -3765,7 +3765,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="66a13ad4-c7e1-40ab-9d08-4e1d288467d0" name="Monster of a Minotaur">
-   <property name="Number" value="183" />
+   <property name="Number" value="PR183" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3785,7 +3785,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="5d7b0bfd-7c07-45ba-a0a0-a96234597054" name="My Pinkie Sense is Tingling">
-   <property name="Number" value="184" />
+   <property name="Number" value="PR184" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3795,7 +3795,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="The winner of a Problem faceoff here may look at the top three cards of this Problem dekc and put them back in any order." />
+   <property name="Text" value="When a player wins a Problem faceoff here, they may look at the top 3 cards of this Problem's deck and put them back in any order." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="6" />
    <property name="ProblemPlayerElement1" value="Laughter" />
@@ -3805,7 +3805,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="9cc29e98-4536-4faf-a8a9-571ec8fce754" name="Maybes are for Babies">
-   <property name="Number" value="185" />
+   <property name="Number" value="PR185" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3815,7 +3815,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When a player confonts this Problem, that player may draw a card." />
+   <property name="Text" value="When a player confronts this Problem, that player may draw a card." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="9" />
    <property name="ProblemPlayerElement1" value="Laughter" />
@@ -3825,7 +3825,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="c685434d-42f1-42d4-9b41-38e9195c9b1d" name="Fashion Feast">
-   <property name="Number" value="186" />
+   <property name="Number" value="PR186" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3835,7 +3835,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Cards flipped for Problem faceoffs at this Problem are not put at the bottom of their players' decks, but discarded instead." />
+   <property name="Text" value="If a card flipped for a Problem faceoff here would be put on the bottom of its owner's deck, it is put into its owner's discard pile instead." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="6" />
    <property name="ProblemPlayerElement1" value="Generosity" />
@@ -3845,7 +3845,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="5248ceb5-e93c-49bf-af4f-986e7d3bd3e5" name="Parasprite Pandemic">
-   <property name="Number" value="187" />
+   <property name="Number" value="PR187" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3865,7 +3865,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="a1bf6f5e-24aa-4859-be65-c6c71b3a4b7e" name="Ponyville in a Bottle">
-   <property name="Number" value="188" />
+   <property name="Number" value="PR188" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3875,7 +3875,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Friends with less than two power can't be played to this Problem." />
+   <property name="Text" value="Friends with less than 2 power can't be played to this Problem." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Magic" />
@@ -3885,7 +3885,7 @@
    <property name="Rarity" value="C" />
   </card>
   <card id="cb7fc8ed-22ce-4c85-88e2-de647b7df061" name="Raze This Barn">
-   <property name="Number" value="189" />
+   <property name="Number" value="PR189" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3905,7 +3905,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="3fb34bed-b5c2-463e-9712-dc53045e4aa3" name="Runaway Cart">
-   <property name="Number" value="190" />
+   <property name="Number" value="PR190" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3925,7 +3925,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="ee137bc6-c5af-498e-9366-306ac7aecec6" name="Save Sweet Apple Acres">
-   <property name="Number" value="191" />
+   <property name="Number" value="PR191" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3945,7 +3945,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="faacdbeb-fb15-4466-a24b-68059d3cfa26" name="Special Delivery!">
-   <property name="Number" value="192" />
+   <property name="Number" value="PR192" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3965,7 +3965,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="17ac19c6-8b24-489c-9d2c-68de7876b135" name="Ponynapped!">
-   <property name="Number" value="193" />
+   <property name="Number" value="PR193" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3985,7 +3985,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="ef908e82-b9be-4ee5-9ace-0f4fad5ae2a7" name="This Way, Little Ones">
-   <property name="Number" value="194" />
+   <property name="Number" value="PR194" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3995,7 +3995,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this Problem is played, its owner may move one of their [Critter] Friends here from home for free." />
+   <property name="Text" value="When this Problem is played, its owner may move one of their Critter Friends here from home for free." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="6" />
    <property name="ProblemPlayerElement1" value="Kindness" />
@@ -4005,7 +4005,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="7a19cf83-2018-4f01-bf34-73c2dac0c6f9" name="Want it, Need it!">
-   <property name="Number" value="195" />
+   <property name="Number" value="PR195" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -4015,7 +4015,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="The first player to confront this Problem with a [Honesty] character with at least three power scores an additional point." />
+   <property name="Text" value="The first player to confront this Problem with a [Honesty] character with at least 3 power scores an additional point." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="6" />
    <property name="ProblemPlayerElement1" value="Honesty" />
@@ -4025,7 +4025,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="bd147b30-8dcb-47ce-9323-5b8f97f61554" name="Wrapping Up Winter">
-   <property name="Number" value="196" />
+   <property name="Number" value="PR196" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -4035,7 +4035,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="The first player to play a Friend to this Problem gains 2" />
+   <property name="Text" value="The first player to play a Friend to this Problem gains 2AT." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Magic" />
@@ -4045,7 +4045,7 @@
    <property name="Rarity" value="U" />
   </card>
   <card id="28b9716e-8d59-4ac7-a7f3-66f930379b1b" name="Dr. Hooves">
-   <property name="Number" value="197" />
+   <property name="Number" value="PR197" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Unblinking" />
@@ -4055,7 +4055,7 @@
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card is placed in the discard pile, you may search you deck for a Dr. Hooves Friend. Play it to you home frightened, and shuffle your deck." />
+   <property name="Text" value="When this card is put into the discard pile from anywhere, you may search your deck for Dr. Hooves, play it to your home frightened for free, and shuffle your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4065,7 +4065,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="7c6d7a2d-1455-4f5b-8e75-1ab9e4e47679" name="Rainbow Dash">
-   <property name="Number" value="198" />
+   <property name="Number" value="PR198" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Winged Wonder" />
@@ -4074,8 +4074,8 @@
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Swift" />
-   <property name="Text" value="When you play this card to a Problem, you may move up to three of your Friends to that Problem for free." />
+   <property name="Keywords" value="Swift." />
+   <property name="Text" value="When you play this card to a Problem, you may move up to 3 of your Friends to that Problem for free." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4085,7 +4085,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="40d18b76-148f-4c6c-8910-2332e93a7eb0" name="Big Mac">
-   <property name="Number" value="199" />
+   <property name="Number" value="PR199" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Immense Apple" />
@@ -4105,7 +4105,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="15cd2bd3-e9d5-4207-92b3-41f16846c06d" name="Ship Shape">
-   <property name="Number" value="200" />
+   <property name="Number" value="PR200" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Heavy Lifter" />
@@ -4115,7 +4115,7 @@
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff Reaction: When you flip a card, exhaust this card to ignore that card's power and flip a new card." />
+   <property name="Text" value="Reaction: When you flip a card, exhaust this card to ignore that card and flip another card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4125,7 +4125,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="5ea49898-c749-4ed2-9b47-5bf813f32812" name="Lyra Heartstrings">
-   <property name="Number" value="201" />
+   <property name="Number" value="PR201" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Bonafide" />
@@ -4145,7 +4145,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="7735f2cf-e494-4f2f-b2f9-581cc79172a8" name="Screwy">
-   <property name="Number" value="202" />
+   <property name="Number" value="PR202" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Barking Mad" />
@@ -4155,7 +4155,7 @@
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Critter, Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Your opponent needs at least three characters to confront this card's Problem." />
+   <property name="Text" value="Your opponents can't confront this card's Problem unless they have at least 3 characters at that Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4165,7 +4165,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="9fe3cf12-43b0-46cd-8557-4f5d3eaa1f3b" name="Twilight Sparkle">
-   <property name="Number" value="203" />
+   <property name="Number" value="PR203" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Ursa Vanquisher" />
@@ -4174,8 +4174,8 @@
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Studious" />
-   <property name="Text" value="Main Phase: While this card is at a Problem, you may exhaust and put it into your hand. If you do, move up to 2 of your opponent's characters home." />
+   <property name="Keywords" value="Studious." />
+   <property name="Text" value="Main Phase: While this card is at a Problem, you may exhaust this card and put it into your hand. If you do, move up to 2 of your opponent's characters home." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4185,7 +4185,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="1c158a21-cc05-46e2-b2f1-9887b87e426e" name="Zecora">
-   <property name="Number" value="204" />
+   <property name="Number" value="PR204" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Everfree Guru" />
@@ -4205,7 +4205,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="8b01aa2d-7c77-4060-8a85-debf75db770f" name="Octavia">
-   <property name="Number" value="205" />
+   <property name="Number" value="PR205" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Virtuoso" />
@@ -4215,7 +4215,7 @@
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Your opponent must pay +2 to move a character to this card's Problem." />
+   <property name="Text" value="Your opponent must pay +2AT to move a character to or from this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4225,7 +4225,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="98ac364f-a67f-45b3-aab9-c2f69f676f26" name="Rarity">
-   <property name="Number" value="206" />
+   <property name="Number" value="PR206" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Truly Outrageous" />
@@ -4245,7 +4245,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="2bc8f5b7-4667-4ace-96ad-4c0993b0bd05" name="Philomena">
-   <property name="Number" value="207" />
+   <property name="Number" value="PR207" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Bird of a Feather" />
@@ -4255,7 +4255,7 @@
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Critter" />
    <property name="Keywords" value="" />
-   <property name="Text" value="While this card is at a Problem, your other Friends at that Problem get the Critter trait during any Score Phase." />
+   <property name="Text" value="Whille this card is at a Problem, your other Friends at that Problem get the Critter trait during any Score Phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4265,7 +4265,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="daf8974b-8784-4bff-b1f7-2052a5090181" name="Princess Celestia">
-   <property name="Number" value="208" />
+   <property name="Number" value="PR208" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Ray of Sunshine" />
@@ -4285,7 +4285,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="f0a24546-85a2-4f46-9d94-fe88bdb904a1" name="Heart's Desire">
-   <property name="Number" value="209" />
+   <property name="Number" value="PR209" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -4294,8 +4294,8 @@
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Faceoff Reaction: When you win a faceoff, you may dismiss this card to gain 4." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Faceoff Reaction: When you win a faceoff, you may dismiss this card to gain 4AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4305,7 +4305,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="cf031f16-4e96-436a-a846-4701f8307ce0" name="Nightmare Moon">
-   <property name="Number" value="210" />
+   <property name="Number" value="PR210" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -4313,9 +4313,9 @@
    <property name="Cost" value="" />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="" />
+   <property name="Traits" value="Epic" />
    <property name="Keywords" value="Villain." />
-   <property name="Text" value="When you uncover this card, all players discard their hands and draw three cards. At the start of each player's Troublemaker Phase, that player discards a random card." />
+   <property name="Text" value="When this card is uncovered, all players discard their hands and draw 3 cards.&#10;At the start of each player's Troublemaker Phase, that player discards a random card." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4325,7 +4325,7 @@
    <property name="Rarity" value="UR" />
   </card>
   <card id="fd01e8a2-b683-4fba-a905-5cda0c1fd567" name="Fluttershy">
-   <property name="Number" value="211" />
+   <property name="Number" value="PR211" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Monster Tamer" />
@@ -4335,7 +4335,7 @@
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card to a Problem, you may banish a Troublemaker at that Problem. When this card is moved from that Problem, dismissed, or banished, play that banished Troublemaker to a Problem and reveal it." />
+   <property name="Text" value="When you play this card to a Problem, you may banish a Troublemaker there. When this card leaves that Problem, put that banished Troublemaker into play at a Problem and uncover it." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />

--- a/Sets/8155e8f5-7485-40c2-9f7a-525000dbbee6/set.xml
+++ b/Sets/8155e8f5-7485-40c2-9f7a-525000dbbee6/set.xml
@@ -1,6 +1,26 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<set name="Crystal Games" id="8155e8f5-7485-40c2-9f7a-525000dbbee6" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="3.1.0.0" version="3.0">
+<set name="Crystal Games" id="8155e8f5-7485-40c2-9f7a-525000dbbee6" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="2.2.4.4" version="3.1">
  <cards>
+  <card id="b4b25356-7be9-4a16-b8af-8c4cd6421f02" name="Princess Twilight Sparkle">
+   <property name="Number" value="CG00" />
+   <property name="Type" value="Friend" />
+   <property name="Element" value="Magic" />
+   <property name="Subname" value="Princess of Friendship" />
+   <property name="Power" value="3" />
+   <property name="Cost" value="5" />
+   <property name="PlayRequiredPower" value="3" />
+   <property name="PlayRequiredElement" value="Magic" />
+   <property name="Traits" value="Alicorn, Royalty" />
+   <property name="Keywords" value="Studious, Swift." />
+   <property name="Text" value="When you play this card, gain 1AT for each opposing character at this card's Problem." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="UR" />
+  </card>
   <card id="ee9218c3-acbb-44de-b184-6772d0024dff" name="Cutie Mark Crusaders">
    <property name="Number" value="CG1" />
    <property name="Type" value="Mane Character" />
@@ -20,26 +40,26 @@
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
-     <alternate name="Cutie Mark Crusaders" type="Mane Character Boosted">
-      <property name="Number" value="CG1" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Laughter" />
-      <property name="Subname" value="Ponyville Flag Carriers" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Earth Pony, Pegasus, Unicorn, Foal" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="When a Problem enters play, you may exhaust this card and pay 2 to replace it." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="F" />
-  </alternate>
+   <alternate name="Cutie Mark Crusaders" type="Mane Character Boosted">
+    <property name="Number" value="CG1" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Laughter" />
+    <property name="Subname" value="Ponyville Flag Carriers" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Earth Pony, Pegasus, Unicorn, Foal" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="When a Problem enters play, you may exhaust this card and pay 2AT to replace it." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
   <card id="30a2fabe-9009-4aa4-ab2e-54950f5100ab" name="Spike">
    <property name="Number" value="CG2" />
@@ -60,28 +80,27 @@
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
-     <alternate name="Spike" type = "Mane Character Boosted">
-      <property name="Number" value="CG2" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Magic" />
-      <property name="Subname" value="Crystal Hero" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Dragon" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="Main Phase: Exhaust this card to turn an opponent's Troublemaker here face-down." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="F" />
-  </alternate>
+   <alternate name="Spike" type="Mane Character Boosted">
+    <property name="Number" value="CG2" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Magic" />
+    <property name="Subname" value="Crystal Hero" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Dragon" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="Main Phase: Exhaust this card to turn an opponent's Troublemaker here face-down." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
-
   <card id="e93db302-6c6b-4269-b39b-1ac55d134f94" name="Princess Cadance">
    <property name="Number" value="CG3" />
    <property name="Type" value="Mane Character" />
@@ -91,7 +110,7 @@
    <property name="Cost" value="" />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Alicorn" />
+   <property name="Traits" value="Royalty, Alicorn" />
    <property name="Keywords" value="Home Limit 3." />
    <property name="Text" value="When an opponent's Friend enters play here, put a Shield counter on this card. Then, if there are at least 5 Shield counters on this card, remove them and turn it over." />
    <property name="ProblemBonus" value="" />
@@ -101,26 +120,26 @@
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
-     <alternate name="Princess Cadance" type="Mane Character Boosted">
-      <property name="Number" value="CG3" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Generosity" />
-      <property name="Subname" value="Loving Ruler" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Alicorn" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="Opponents pay +2 to play Friends here." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="F" />
-  </alternate>
+   <alternate name="Princess Cadance" type="Mane Character Boosted">
+    <property name="Number" value="CG3" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Generosity" />
+    <property name="Subname" value="Loving Ruler" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Royalty, Alicorn" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="Opponents pay +2AT to play Friends here." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
   <card id="360e7139-9247-4c57-a65f-6a2e3561c2fb" name="Bubbly Mare">
    <property name="Number" value="CG4" />
@@ -133,7 +152,7 @@
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="When an opponent confronts a Problem, put a Postage counter on this card. Then, if there are at least 5 Postage counters on this card, remove them and turn it over." />
+   <property name="Text" value="When you confront a Problem, put a Postage counter on this card. Then, if there are at least 5 Postage counters on this card, remove them and turn it over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -141,26 +160,26 @@
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
-     <alternate name="Bubbly Mare" type="Mane Character Boosted">
-      <property name="Number" value="CG4" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Kindness" />
-      <property name="Subname" value="Helping Hoof" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Pegasus" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="Opponents can't play more than one card of each type per turn." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="F" />
-  </alternate>
+   <alternate name="Bubbly Mare" type="Mane Character Boosted">
+    <property name="Number" value="CG4" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Kindness" />
+    <property name="Subname" value="Helping Hoof" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Pegasus" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="Opponents can't play more than one card of each type per turn." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
   <card id="c5482faf-89e0-4a3a-a653-66b9d6557d99" name="Bolt">
    <property name="Number" value="CG5" />
@@ -172,8 +191,8 @@
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Teamwork" />
-   <property name="Text" value="Main Phase: Pay 2 to ready this card." />
+   <property name="Keywords" value="Teamwork." />
+   <property name="Text" value="Main Phase: Pay 2AT to ready this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -192,9 +211,8 @@
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Pumped" />
-   <property name="Text" value="This card has +1 power for each card beneath it.
-At the start of your Score Phase, if this card has at least 4 power, you may move it." />
+   <property name="Keywords" value="Pumped." />
+   <property name="Text" value="This card has +1 power for each card beneath it.&#10;At the start of the Score Phase, if this card has at least 4 power, you may move it." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -214,7 +232,7 @@ At the start of your Score Phase, if this card has at least 4 power, you may mov
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Pay 1 to give this card +2 power until the end of the turn. You may move this card. At the end of the turn, retire this card." />
+   <property name="Text" value="Main Phase: Pay 1AT to give this card +2 power until the end of the turn. You may move this card. At the end of the turn, retire this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -234,7 +252,7 @@ At the start of your Score Phase, if this card has at least 4 power, you may mov
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Crystal" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you move this card to a Problem, you may exhaust this card and pay 1 to frighten an opponent's Friend there." />
+   <property name="Text" value="When you move this card to a Problem, you may exhaust this card and pay 1AT to frighten an opponent's Friend there." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -254,7 +272,7 @@ At the start of your Score Phase, if this card has at least 4 power, you may mov
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card enters play at a Problem, challenge an opponent's Troublemaker there with your charaters there." />
+   <property name="Text" value="When this card enters play at a Problem, challenge an opponent's Troublemaker there with your characters there." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -274,8 +292,7 @@ At the start of your Score Phase, if this card has at least 4 power, you may mov
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card becomes unfrightened, you may move it to a problem.
-This card has +1 power for each Dr. Hooves Friend in your discard pile." />
+   <property name="Text" value="When this card becomes unfrightened, you may move it to a Problem.&#10;This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -291,8 +308,8 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="Subname" value="Agile Athlete" />
    <property name="Power" value="2" />
    <property name="Cost" value="3" />
-   <property name="PlayRequiredPower" value="1" />
-   <property name="PlayRequiredElement" value="Loyalty" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Crystal" />
    <property name="Keywords" value="" />
    <property name="Text" value="While with another of your Crystal characters, this card has Swift." />
@@ -334,8 +351,8 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Crystal" />
-   <property name="Keywords" value="Prismatic" />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 2 to move a Friend you control for each color this card this has." />
+   <property name="Keywords" value="Prismatic." />
+   <property name="Text" value="Main Phase: Exhaust this card and pay 2AT to move a Friend you control for each color this card has." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -375,7 +392,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Earth Pony, Elder" />
    <property name="Keywords" value="" />
-   <property name="Text" value="While with at least one of your [Pegasus] characters, this card has Swift." />
+   <property name="Text" value="While with at least one of your Pegasus characters, this card has Swift." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -414,7 +431,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Teamwork, Supportive 1" />
+   <property name="Keywords" value="Teamwork, Supportive 1." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -494,7 +511,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Crystal" />
-   <property name="Keywords" value="Prismatic" />
+   <property name="Keywords" value="Prismatic." />
    <property name="Text" value="This card has +2 power for each color it has." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -514,7 +531,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredPower" value="5" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Teamwork, Supportive 2" />
+   <property name="Keywords" value="Teamwork, Supportive 2." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -634,8 +651,8 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Stubborn" />
-   <property name="Text" value="Main Phase: Exhaust one of your [Earth Pony] characters here to exhaust an opponent's Friend here." />
+   <property name="Keywords" value="Stubborn." />
+   <property name="Text" value="Main Phase: Exhaust one of your Earth Pony characters here to exhaust an opponent's Friend here." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -655,7 +672,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Dragon" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card enters play it getrs +3 power until the end of turn." />
+   <property name="Text" value="When this card enters play, it gets +3 power until the end of turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -675,7 +692,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="You may pay 1 less to play this card to a Problem for each of your [Earth Pony] Friends there." />
+   <property name="Text" value="You may pay 1AT less to play this card to a Problem for each of your Earth Pony Friends there." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -694,7 +711,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Teamwork" />
+   <property name="Keywords" value="Teamwork." />
    <property name="Text" value="This card can't be frightened." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -735,7 +752,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="At the start of a faceoff involving this card, you may exhaust this card and pay 1 to gain control of an opponent's Friend here until the end of the faceoff." />
+   <property name="Text" value="At the start of a faceoff involving this card, you may exhaust this card and pay 1AT to gain control of an opponent's Friend here until the end of the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -755,7 +772,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you confront this card's Problem, if you have a [Unicorn] character here, you may draw a card." />
+   <property name="Text" value="When you confront this card's Problem, if you have a Unicorn character here, you may draw a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -794,7 +811,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Griffon" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Main Phase: Spend a card from beneath this card to uncover a Troublemaker." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -848,14 +865,14 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="Number" value="CG39" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
-   <property name="Subname" value="Very Exitable" />
+   <property name="Subname" value="Very Excitable" />
    <property name="Power" value="1" />
    <property name="Cost" value="3" />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play an [Earth Pony] friend here, you may exhaust this card and pay 1 to dismiss an opponent's Friend here." />
+   <property name="Text" value="When you play an Earth Pony Friend here, you may exhaust this card and pay 1AT to dismiss an opponent's Friend here." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -875,8 +892,7 @@ This card has +1 power for each Dr. Hooves Friend in your discard pile." />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Crystal" />
    <property name="Keywords" value="" />
-   <property name="Text" value="During a faceoff involving this card, if you would put any number of flipped cards on the bottom of your deck, you may banish them to beneath this card instead.
-Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with Pumped." />
+   <property name="Text" value="During a faceoff involving this card, if you would put any number of flipped cards on the bottom of your deck, you may banish them to beneath this card instead.&#10;Main Phase: Pay 1AT to put a card from beneath this card to beneath a Friend with Pumped." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -895,7 +911,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Teamwork, Supportive 1" />
+   <property name="Keywords" value="Teamwork, Supportive 1." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -916,7 +932,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Breezie" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: After the start of the Score Phase, you may retire this card. If you do, your opponent needs +2 [Any] to confront this card's Problem this turn." />
+   <property name="Text" value="Reaction: After the start of the Score Phase, you may retire this card. If you do, your opponent needs +2 power to confront this card's Problem this turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -935,7 +951,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Crystal" />
-   <property name="Keywords" value="Prismatic" />
+   <property name="Keywords" value="Prismatic." />
    <property name="Text" value="During faceoffs involving this card, you may flip a number of additional cards equal to the number of colors this card has, then choose one of the cards flipped this way and ignore the rest." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -955,8 +971,8 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Teamwork" />
-   <property name="Text" value="While this card is ready, your opponent needs +1 [Any] to confront this card's Problem." />
+   <property name="Keywords" value="Teamwork." />
+   <property name="Text" value="While this card is ready, your opponent needs +1 power to confront this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1016,7 +1032,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When an opponent plays a Friend, gain 1." />
+   <property name="Text" value="When an opponent plays a Friend, gain 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1036,7 +1052,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you lose a Problem faceoff involving this card, gain 1." />
+   <property name="Text" value="When you lose a Problem faceoff involving this card, gain 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1069,14 +1085,14 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="Number" value="CG50" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
-   <property name="Subname" value="Officous Official" />
+   <property name="Subname" value="Officious Official" />
    <property name="Power" value="2" />
    <property name="Cost" value="4" />
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Teamwork" />
-   <property name="Text" value="When you confront this card's Problem, you may exhaust this card and pay 1 to move an opposing character at this card's Problem home." />
+   <property name="Keywords" value="Teamwork." />
+   <property name="Text" value="When you confront this card's Problem, you may exhaust this card and pay 1AT to move an opposing character at this card's Problem home." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1095,7 +1111,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Teamwork, Supportive 1" />
+   <property name="Keywords" value="Teamwork, Supportive 1." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1155,7 +1171,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Teamwork" />
+   <property name="Keywords" value="Teamwork." />
    <property name="Text" value="When you play an Event, this card gets +1 power until the end of the turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1216,7 +1232,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust one of your [Earth Pony] characters here to banish a card from a discard pile." />
+   <property name="Text" value="Main Phase: Exhaust one of your Earth Pony characters here to banish a card from a discard pile." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1295,7 +1311,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Crystal" />
-   <property name="Keywords" value="Prismatic" />
+   <property name="Keywords" value="Prismatic." />
    <property name="Text" value="At the start of a Problem faceoff involving this card, you may choose an opposing character involved in the faceoff with power less than or equal to the number of colors this card has. If you do, that character ceases to be involved in the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1335,7 +1351,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Teamwork, Supportive 1" />
+   <property name="Keywords" value="Teamwork, Supportive 1." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1375,8 +1391,8 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Teamwork" />
-   <property name="Text" value="When you win a Problem faceoff involving this card, you may exhaust this card and pay 2 to banish a Friend at that problem." />
+   <property name="Keywords" value="Teamwork." />
+   <property name="Text" value="When you win a Problem faceoff involving this card, you may exhaust this card and pay 2AT to banish a Friend at that Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1476,7 +1492,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Breezie" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you win a faceoff involving this card, you amy retire it to score a point." />
+   <property name="Text" value="When you win a faceoff involving this card, you may retire it to score a point." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1495,8 +1511,8 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Crystal" />
-   <property name="Keywords" value="Prismatic" />
-   <property name="Text" value="Main Phase: Exhaust this card to choose an opponent. Look at a number of cards from the top of that player's deck equal to the number of colors thyis card has, then put any number of them back on the top of the deck in any order, and the rest on the bottom." />
+   <property name="Keywords" value="Prismatic." />
+   <property name="Text" value="Main Phase: Exhaust this card to choose an opponent. Look at a number of cards from the top of that player's deck equal to the number of colors this card has, then put any number of them back on top of the deck in any order, and the rest on the bottom." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1516,7 +1532,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="While this card has power higher than another other Friend here, you may pay 1 less to play Accessories." />
+   <property name="Text" value="While this card has power higher than any other Friend here, you may pay 1AT less to play Accessories." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1556,7 +1572,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn, Foal, Performer" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to sing a song and have all players put a Friend from their discard piles into their hands." />
+   <property name="Text" value="Main Phase: Exhaust this card and pay 1AT to sing a song and have all players put a Friend from their discard piles into their hands." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1575,8 +1591,8 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Teamwork" />
-   <property name="Text" value="When this card leaves play, you may pay 1 to put another card from your discard pile into your hand." />
+   <property name="Keywords" value="Teamwork." />
+   <property name="Text" value="When this card leaves play, you may pay 1AT to put another card from your discard pile into your hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1596,7 +1612,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Your [Unicorn] characters here can't be moved by opponents." />
+   <property name="Text" value="Your Unicorn characters here can't be moved by opponents." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1615,7 +1631,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Teamwork" />
+   <property name="Keywords" value="Teamwork." />
    <property name="Text" value="Troublemakers here have -1 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1676,8 +1692,7 @@ Main Phase: Pay 1 to put a card from beneath this card to beneath a Friend with 
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play your first card each turn, put a Postage counter on this card.
-While this card has at least one Postage counter on it, it has +1 power." />
+   <property name="Text" value="When you play your first card each turn, put a Postage counter on this card.&#10;While this card has at least one Postage counter on it, it has +1 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1696,7 +1711,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Critter" />
-   <property name="Keywords" value="Teamwork, Supportive 1" />
+   <property name="Keywords" value="Teamwork, Supportive 1." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1717,7 +1732,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Breezie" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Retire this card to put one of your [Critter] Friends into its owner's hand." />
+   <property name="Text" value="Main Phase: Retire this card to put one of your Critter Friends into its owner's hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1736,8 +1751,8 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Crystal" />
-   <property name="Keywords" value="Prismatic" />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to reveal a number of cards from the top of your deck equal to the number of colors this card has. Put each Friend revealed this way into your hand and the rest on the bottom of your deck." />
+   <property name="Keywords" value="Prismatic." />
+   <property name="Text" value="Main Phase: Exhaust this card and pay 1AT to reveal a number of cards from the top of your deck equal to the number of colors this card has. Put each Friend revealed this way into your hand and the rest of the cards on the bottom of your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1777,7 +1792,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Earth Pony, Elder" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card enters play at a Problem, you may choose a [Critter] Friend from your discard pile with cost 1 or less and put it into play at that Problem." />
+   <property name="Text" value="When this card enters play at a Problem, you may choose a Critter Friend from your discard pile with cost 1AT or less and put it into play at that Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1797,7 +1812,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Critter" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When an opponent flips a card while this card is involved in a faceoff, if that opponent has more flippe cards than you, flip a card." />
+   <property name="Text" value="When an opponent flips a card while this card is involved in a faceoff, if that opponent has more flipped cards than you, flip a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1816,8 +1831,8 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Critter" />
-   <property name="Keywords" value="Pumped" />
-   <property name="Text" value="If you would flip a card during a faceoff involving this card, you may spend a card from beneath this card instead. If you do, add that card's printed power to your total power for that faceoff." />
+   <property name="Keywords" value="Pumped." />
+   <property name="Text" value="If you would flip a card during a faceoff involving this card, you may spend a card from beneath this card instead. If you do, add that card's printed power to your power total for that faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1857,7 +1872,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you win a faceoff involving this card, if you have a [Pegasus] character here, you may exhaust this card to dismiss an opponent's Resource." />
+   <property name="Text" value="When you win a faceoff involving this card, if you have a Pegasus character here, you may exhaust this card to dismiss an opponent's Resource." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1906,7 +1921,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
   </card>
-  <card id="49636148-3f2d-40a7-ad31-78fc743ef00e" name="A Simple Mix-Up">
+  <card id="49636148-3f2d-40a7-ad31-78fc743ef00e" name="A Simple Mix-up">
    <property name="Number" value="CG92" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
@@ -1977,7 +1992,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: Gain 3. At the end of the faceoff, lose all of your action tokens." />
+   <property name="Text" value="Faceoff: Gain 3AT. At the end of the faceoff, lose all of your action tokens." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2037,7 +2052,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: At the start of a Score Phase, move all chracters at a Problem home." />
+   <property name="Text" value="Reaction: After the start of a Score Phase, move all characters at a Problem home." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2077,7 +2092,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: After an opponent moves a character, that opponent must pay 1 if able." />
+   <property name="Text" value="Reaction: After an opponent moves a character, that opponent must pay 1AT if able." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2233,11 +2248,11 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="Subname" value="" />
    <property name="Power" value="5" />
    <property name="Cost" value="2" />
-   <property name="PlayRequiredPower" value="2" />
+   <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust one of your Friends to exhaust a number of opposing Friends up to the number of colors that Friend hase." />
+   <property name="Text" value="Main Phase: Exhaust one of your Friends to exhaust a number of opposing Friends up to the number of colors that Friend has." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2277,7 +2292,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: Atfter the start of a Score Phase, choose a Problem and ready any number of characters there." />
+   <property name="Text" value="Reaction: After the start of a Score Phase, choose a Problem and ready any number of characters there." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2317,7 +2332,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Showdown" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters at that Problem. The winner of that faceoff may banish a Friend that was involved." />
+   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters there. The winner of that faceoff may banish a Friend that was involved." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2337,7 +2352,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Showdown" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters at that Problem. The winner of that faceoff may move a character they control for each of their Friends involved in the faceoff." />
+   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters there. The winner of that faceoff may move a character they control for each of their Friends involved in the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2357,7 +2372,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: Banish a Friend from a discard pile. Add that Friend's power to one of your friends in the faceoff until the end of the faceoff." />
+   <property name="Text" value="Faceoff: Banish a Friend from a discard pile. Add that Friend's power to one of your Friends involved in the faceoff until the end of the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2397,7 +2412,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Showdown" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters at that Problem. The winner of that faceoff may move each opposing character involved in the faceoff home." />
+   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters at that Problem. The winner of the faceoff may move each opposing character involved in the faceoff home." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2417,7 +2432,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Showdown" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters at that Problem. The winner of that faceoff reveals a number of cards from their deck equal to the number of their characters involved in the facoeff, puts each Friend revealed this way into their hand, and puts the rest of the cards on the bottom of their deck." />
+   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters there. The winner of that faceoff reveals a number of cards from the top of their deck equal to the number of their characters involved in the faceoff, puts each Friend revealed this way into their hand, and puts the rest of the cards on the bottom of their deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2431,7 +2446,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
-   <property name="Power" value="2" />
+   <property name="Power" value="3" />
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
@@ -2477,7 +2492,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: After an opponent plays a card, exhaust all opposing Friends with Resources attached to them and banish all cards in all discard piles." />
+   <property name="Text" value="Reaction: After an opponent plays a card, exhaust all opposing Friends with Resources attached to them and banish all cards in a discard pile." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2517,7 +2532,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Showdown" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters at that Problem. The loser of that faceoff discards a card for each of their characters involved in that faceoff." />
+   <property name="Text" value="Main Phase: Start a faceoff involving your characters at a Problem and an opponent's characters there. The loser of that faceoff discards a card for each of their characters involved in that faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2537,7 +2552,7 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: Aftera  Friend becomes unfrightened, frighten that friend." />
+   <property name="Text" value="Reaction: After a Friend becomes unfrightened, frighten that Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2576,9 +2591,8 @@ While this card has at least one Postage counter on it, it has +1 power." />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Retire this card and pay 1 to have all players shuffle their decks. Draw 3 cards.
-Main Phase: Retire this card to give one of your characters [Laughter] until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Retire this card and pay 1AT to have all players shuffle their decks. Draw 3 cards.&#10;Main Phase: Retire this card to give one of your characters [Laughter] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2597,8 +2611,8 @@ Main Phase: Retire this card to give one of your characters [Laughter] until the
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="That friend has +2 power and is Crystal." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;That Friend has +2 power and is Crystal." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2617,9 +2631,8 @@ Main Phase: Retire this card to give one of your characters [Laughter] until the
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Retire this card and pay 2 to put a Resource from your discard pile into your hand.
-Main Phase: Retire this card to give one of your characters [Generosity] until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Retire this card and pay 2AT to put a Resource from your discard pile into your hand.&#10;Main Phase: Retire this card to give one of your characters [Generosity] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2638,8 +2651,8 @@ Main Phase: Retire this card to give one of your characters [Generosity] until t
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Problem" />
-   <property name="Text" value="Opponents must pay +1 to rally Friends here." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on an a Problem.&#10;Opponents must pay +1AT to rally Friends here." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2658,9 +2671,8 @@ Main Phase: Retire this card to give one of your characters [Generosity] until t
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play on a Problem" />
-   <property name="Text" value="That Problem can't be confronted.
-Main Phase: Pay 3 to banish this card. Any player may activate this ability." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Problem.&#10;That Problem can't be confronted.&#10;Main Phase: Pay 3AT to banish this card. Any player may activate this ability." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2679,8 +2691,8 @@ Main Phase: Pay 3 to banish this card. Any player may activate this ability." />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="While that Friend has power higher than any other Friend here, Friends can't be moved to this card's Problem." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;While that Friend has power higher than any other Friend here, Friends can't be moved to this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2699,8 +2711,8 @@ Main Phase: Pay 3 to banish this card. Any player may activate this ability." />
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="That Friend has +1 Power, is also [Generosity], and loses and can't gain abilities." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;That Friend has +1 Power, is also White, and loses and can't gain abilities." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2719,8 +2731,8 @@ Main Phase: Pay 3 to banish this card. Any player may activate this ability." />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Pay 1 to gain control of an opponent's non-attachment Resource. That opponent gains control of this card." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Pay 1AT to gain control of an opponent's nonattachment Resource. That opponent gains control of this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2739,8 +2751,8 @@ Main Phase: Pay 3 to banish this card. Any player may activate this ability." />
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on an [Honesty] Friend." />
-   <property name="Text" value="Main Phase: Discard a card to give that Friend +1 power until the end of the turn." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on an [Honesty] Friend.&#10;Main Phase: Discard a card to give that Friend +1 power until the end of the turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2759,8 +2771,8 @@ Main Phase: Pay 3 to banish this card. Any player may activate this ability." />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="That Friend has [Laughter] and +1 power for each of your other [Laughter] Friends here." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;That Friend has [Laughter] and +1 power for each of your other [Laughter] Friends here." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2779,9 +2791,8 @@ Main Phase: Pay 3 to banish this card. Any player may activate this ability." />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Accessory, Armor" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="While involved in a faceoff, that Friend has +1 power.
-Faceoff: Exhaust this card to move that Friend to a Problem. At the end of the faceoff, retire this card." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;While involved in a faceoff, that Friend has +1 power.&#10;Faceoff: Exhaust this card to move that Friend to a Problem. At the end of the faceoff, retire this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2800,8 +2811,8 @@ Faceoff: Exhaust this card to move that Friend to a Problem. At the end of the f
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Mailbox" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Remove a counter from one of your ready characters to draw a card. If you remove the counter from a Dragon or Pegasus, draw 2 cards instead." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Remove a counter from one of your ready characters to draw a card. If you remove the counter from a Dragon or Pegasus, draw 2 cards instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2820,8 +2831,8 @@ Faceoff: Exhaust this card to move that Friend to a Problem. At the end of the f
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="Exhaust that Friend. That Friend does not ready during the Ready Phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;Exhaust that Friend. That Friend does not ready during the Ready Phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2840,9 +2851,8 @@ Faceoff: Exhaust this card to move that Friend to a Problem. At the end of the f
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="At the start of your turn, you may put a Party counter on this card.
-Main Phase: Pay a number of action tokens equal to the number of Party counters on this card and retire it to dismiss all Friends with printed power equal to the number of Party counters on this card." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="At the start of your turn, you may put a Party counter on this card.&#10;Main Phase: Pay a number of action tokens equal to the number of Party counters on this card and retire it to dismiss all Friends with printed power equal to the number of Party counters on this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2860,10 +2870,9 @@ Main Phase: Pay a number of action tokens equal to the number of Party counters 
    <property name="Cost" value="0" />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Asset, Unique" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="When an opponent draws a card during their Main Phase, if that opponent already has drawn at least 4 cards this turn, score a point.
-When an opponent draws a card during their Main Phase, you may exhaust this card and one of your Friends to draw a card." />
+   <property name="Traits" value="Resource, Asset, Unique" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;When your opponent draws a card during their Main Phase, if that opponent has drawn at least 4 cards this turn, score a point.&#10;When an opponent draws a card during their Main Phase, you may exhaust this card and one of your Friends to draw a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2882,8 +2891,8 @@ When an opponent draws a card during their Main Phase, you may exhaust this card
    <property name="PlayRequiredPower" value="5" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="You control that Friend." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;You control that Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2902,8 +2911,8 @@ When an opponent draws a card during their Main Phase, you may exhaust this card
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Score Phase: Retire this card to choose a Problem. This turn, you meet the confront requirements of that Problem if you have at least one ready [Unicorn], [Earth Pony], and [Pegasus] character there." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Score Phase: Retire this card to choose a Problem. This turn, you meet the confront requirements of that Problem if you have at least one ready Unicorn, Earth Pony, and Pegasus character there." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2922,8 +2931,8 @@ When an opponent draws a card during their Main Phase, you may exhaust this card
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Mailbox" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Remove a counter from one of your ready characters to give a Friend +1 Power until the end of the turn. If the counter is a Postage counter, give that Friend +2 power instead." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Remove a counter from one of your ready characters to give a Friend +1 Power until the end of the turn. If the counter is a Postage counter, give that Friend +2 Power instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2942,8 +2951,8 @@ When an opponent draws a card during their Main Phase, you may exhaust this card
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on one of your Friends." />
-   <property name="Text" value="Main Phase: Exhaust that Friend to choose a color. That Friend has that color until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on one of your Friends.&#10;Main Phase: Exhaust that Friend to choose a color. That Friend has that color until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2962,8 +2971,8 @@ When an opponent draws a card during their Main Phase, you may exhaust this card
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card to have an opponent reveal a random card from their hand." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card to have an opponent reveal a random card from their hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2982,8 +2991,8 @@ When an opponent draws a card during their Main Phase, you may exhaust this card
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Foal Friend." />
-   <property name="Text" value="Any Phase: Exhaust this card to move that Friend to a Problem." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Foal Friend.&#10;Any Phase: Exhaust this card to move that Friend to a Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3002,9 +3011,8 @@ When an opponent draws a card during their Main Phase, you may exhaust this card
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Retire this card and pay 1 to put a card from your hand on the top of your deck.
-Main Phase: Retire this card to give one of your characters [Magic] until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Retire this card and pay 1AT to put a card from your hand on the top of your deck.&#10;Main Phase: Retire this card to give one of your characters [Magic] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3023,9 +3031,8 @@ Main Phase: Retire this card to give one of your characters [Magic] until the en
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Retire this card and pay 1 to dismiss an opponent's Resource.
-Main Phase: Retire this card to give one of your characters [Kindness] until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Retire this card and pay 1AT to dismiss an opponent's Resource.&#10;Main Phase: Retire this card to give one of your characters [Kindness] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3044,9 +3051,8 @@ Main Phase: Retire this card to give one of your characters [Kindness] until the
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Retire this card and pay 1 to exhaust a character.
-Main Phase: Retire this card to give one of your characters [Honesty] until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Retire this card and pay 1AT to exhaust a character.&#10;Main Phase: Retire this card to give one of your characters [Honesty] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3065,8 +3071,8 @@ Main Phase: Retire this card to give one of your characters [Honesty] until the 
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="That Friend has +1 power for each Slick Shades in play." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;That Friend has +1 power for each Slick Shades in play." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3085,8 +3091,8 @@ Main Phase: Retire this card to give one of your characters [Honesty] until the 
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="When you play a Friend, the attached Friend gets +2 power until the end of the turn." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;When you play a Friend, the attached Friend gets +2 power until the end of the turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3105,9 +3111,8 @@ Main Phase: Retire this card to give one of your characters [Honesty] until the 
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Retire this card and pay 2 to frighten an opponent's Friend.
-Main Phase: Retire this card to give one of your characters [Loyalty] until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Retire this card and pay 2AT to frighten an opponent's Friend.&#10;Main Phase: Retire this card to give one of your characters [Loyalty] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3126,8 +3131,8 @@ Main Phase: Retire this card to give one of your characters [Loyalty] until the 
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="That Friend can't be frightened." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;That Friend can't be frightened." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3146,8 +3151,8 @@ Main Phase: Retire this card to give one of your characters [Loyalty] until the 
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Opposing Friends enter play exhausted." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Opposing Friends enter play exhausted." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3166,9 +3171,8 @@ Main Phase: Retire this card to give one of your characters [Loyalty] until the 
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Artifact, Unique" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="When you play your first Crystal Friend each turn, put a Crystal counter on this card.
-Reaction: At the start of any phase, remove 2 Crystal counters from this card to choose a color and a Friend. That Friend has that color until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;When you play your first Crystal Friend each turn, put a Crystal counter on this card.&#10;Reaction: After the start of any phase, remove 2 Crystal counters from this card to choose a color and a Friend. That Friend has that color until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3177,7 +3181,7 @@ Reaction: At the start of any phase, remove 2 Crystal counters from this card to
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="R" />
   </card>
-  <card id="f1b40dad-b8f3-48e0-ab3b-9b30c7434a40" name="Wonderbolt Academy Invitation">
+  <card id="f1b40dad-b8f3-48e0-ab3b-9b30c7434a40" name="Wonderbolt Academy Invitations">
    <property name="Number" value="CG155" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
@@ -3187,8 +3191,8 @@ Reaction: At the start of any phase, remove 2 Crystal counters from this card to
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Reaction: At the start of any phase, you may exhaust this card to ready one of your Friends. At the end of the phase, retire that Friend." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Reaction: After the start of any phase, you may exhaust this card to ready one of your Friends. At the end of the phase, retire that Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3208,8 +3212,7 @@ Reaction: At the start of any phase, remove 2 Crystal counters from this card to
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Mane Characters can't be involved in Troublemaker faceoffs involving this card.
-Main Phase: Retire this card and pay 2 to turn an opponent's Mane Character to its Start side." />
+   <property name="Text" value="Mane Characters can't be involved in Troublemaker faceoffs involving this card.&#10;Main Phase: Retire this card and pay 2AT to turn an opponent's Mane Character to its Start side." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3229,8 +3232,7 @@ Main Phase: Retire this card and pay 2 to turn an opponent's Mane Character to i
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card is uncovered, pay 2 or dismiss it.
-At the start of each player's Main Phase, that player frightens one of their Friends." />
+   <property name="Text" value="When this card is uncovered, pay 2AT or dismiss it.&#10;At the start of each player's Main Phase, that player frightens one of their Friends." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3250,7 +3252,7 @@ At the start of each player's Main Phase, that player frightens one of their Fri
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="At the start of a faceoff involving this card, you may pay 1 to choose a color, then exhaust all characters involved in that faceoff that have only that color." />
+   <property name="Text" value="At the start of a faceoff involving this card, you may pay 1AT to choose a color, then exhaust all characters involved in that faceoff that have only that color." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3350,7 +3352,7 @@ At the start of each player's Main Phase, that player frightens one of their Fri
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: Pay 1 to give this card +2 power until the end of the faceoff." />
+   <property name="Text" value="Faceoff: Pay 1AT to give this card +2 power until the end of the faceoff." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3369,7 +3371,7 @@ At the start of each player's Main Phase, that player frightens one of their Fri
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="This card has +2 power for each card beneath it." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
@@ -3410,8 +3412,7 @@ At the start of each player's Main Phase, that player frightens one of their Fri
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="At the end of your Troublemaker Phase, put a Unity counter on this card.
-This card can only be challenged by a number of characters up to the number of Unity counters on this card." />
+   <property name="Text" value="At the end of your Troublemaker Phase, put a Unity counter on this card.&#10;This card can only be challenged by a number of characters up to the number of Unity counters on this card." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3471,7 +3472,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Pay 1 to move one of your friends to this Problem, then retire that Friend at the end of the turn. Any player may activate this ability." />
+   <property name="Text" value="Main Phase: Pay 1AT to move one of your Friends to this Problem, then retire that Friend at the end of the turn. Any player may activate this ability." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="9" />
    <property name="ProblemPlayerElement1" value="Loyalty" />
@@ -3510,8 +3511,8 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
-   <property name="Keywords" value="Starting Problem" />
-   <property name="Text" value="During faceoffs here, the player with the most [Unicorn] characters here pays -1 to play Events." />
+   <property name="Keywords" value="Starting Problem." />
+   <property name="Text" value="During faceoffs here, the player with the most Unicorn characters here pays -1AT to play Events." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
    <property name="ProblemPlayerElement1" value="Magic" />
@@ -3530,7 +3531,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
-   <property name="Keywords" value="Starting Problem" />
+   <property name="Keywords" value="Starting Problem." />
    <property name="Text" value="Troublemakers can't be played here." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
@@ -3631,7 +3632,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="If the player with the most [Unicorn] characters here would draw a card during their Ready Phase, they may put a Resource into their hand from their discard pile instead." />
+   <property name="Text" value="If the player with the most Unicorn characters here would draw a card during their Ready Phase, they may put a Resource into their hand from their discard pile instead." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Generosity" />
@@ -3650,8 +3651,8 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
-   <property name="Keywords" value="Starting Problem" />
-   <property name="Text" value="During faceoffs here, the player with the most [Pegasus] characters here ets +2 power." />
+   <property name="Keywords" value="Starting Problem." />
+   <property name="Text" value="During faceoffs here, the player with the most Pegasus characters here gets +2 power." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
    <property name="ProblemPlayerElement1" value="Loyalty" />
@@ -3670,8 +3671,8 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
-   <property name="Keywords" value="Starting Problem" />
-   <property name="Text" value="The player with the most [Unicorn] characters here can draw from the bottom of their deck." />
+   <property name="Keywords" value="Starting Problem." />
+   <property name="Text" value="The player with the most Unicorn characters here can draw from the bottom of their deck." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
    <property name="ProblemPlayerElement1" value="Generosity" />
@@ -3711,7 +3712,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Resources can't be played on this Problem or Friends here." />
+   <property name="Text" value="Resources can't be played on this Problem or on Friends here." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="7" />
    <property name="ProblemPlayerElement1" value="Kindness" />
@@ -3750,8 +3751,8 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
-   <property name="Keywords" value="Starting Problem" />
-   <property name="Text" value="Main Phase: Exhaust two of your [Pegasus] characters here to move another of your characters. Only the player with the most [Pegasus] characters here may activate this ability." />
+   <property name="Keywords" value="Starting Problem." />
+   <property name="Text" value="Main Phase: Exhaust two of your Pegasus characters here to move another one of your characters. Only the player with the most Pegasus characters here may activate this ability." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
    <property name="ProblemPlayerElement1" value="Kindness" />
@@ -3770,8 +3771,8 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
-   <property name="Keywords" value="Starting Problem" />
-   <property name="Text" value="During Faceoffs here, the player with the most [Earth Pony] characters here flips an additional card." />
+   <property name="Keywords" value="Starting Problem." />
+   <property name="Text" value="During faceoffs here, the player with the most Earth Pony characters here flips an additional card." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
    <property name="ProblemPlayerElement1" value="Honesty" />
@@ -3811,7 +3812,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When a player confronts this Problem with characters that have at least 3 different colors among them, that player may exhaust one of their characters here to gain 1." />
+   <property name="Text" value="When a player confronts this Problem with characters that have at least 3 different colors among them, that player may exhaust one of their characters here to gain 1AT." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Magic" />
@@ -3850,8 +3851,8 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
-   <property name="Keywords" value="Starting Problem" />
-   <property name="Text" value="When a player confronts this Problem, that player may banish a card from their hand beneath one of their Friends with Pumped." />
+   <property name="Keywords" value="Starting Problem." />
+   <property name="Text" value="When a player confronts this Problem, that player may banish a card from their hand to beneath one of their Friends with Pumped." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Wild" />
@@ -3891,7 +3892,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="The first player to confront this Problem may pay 3 to score 2 points." />
+   <property name="Text" value="The first player to confront this Problem may pay 3AT to score 2 points." />
    <property name="ProblemBonus" value="0" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Magic" />
@@ -3911,7 +3912,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Unicorn, Royalty" />
    <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="At the start of a Problem faceoff, you may pay 1 to put a Windup counter on this card. If you do, you may turn this card over." />
+   <property name="Text" value="At the start of a Problem faceoff, you may pay 1AT to put a Windup counter on this card. If you do, you may turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3919,28 +3920,27 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="UR" />
-     <alternate name="Princess Cadance" type="Mane Character Boosted">
-      <property name="Number" value="CG191" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Loyalty" />
-      <property name="Subname" value="Fastball Special" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Alicorn, Royalty" />
-      <property name="Keywords" value="Home Limit 4. Swift." />
-      <property name="Text" value="When this side of the card turns face-up, you may move it to a Problem. Then, remove each Windup counter from this card and you may move a number of your Friends to this card's Problem up to the number of counters removed this way." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="UR" />
-  </alternate>
+   <alternate name="Princess Cadance" type="Mane Character Boosted">
+    <property name="Number" value="CG191" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Loyalty" />
+    <property name="Subname" value="Fastball Special" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Alicorn, Royalty" />
+    <property name="Keywords" value="Home Limit 4, Swift." />
+    <property name="Text" value="When this side of the card turns face-up, you may move it to a Problem. Then, remove each Windup counter from this card and you may move a number of your Friends to this card's Problem up to the number of counters removed this way." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="UR" />
+   </alternate>
   </card>
-
   <card id="d16b1a8b-558e-41ec-81b2-a87e17b5f525" name="Spike">
    <property name="Number" value="CG192" />
    <property name="Type" value="Mane Character" />
@@ -3951,7 +3951,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Dragon" />
-   <property name="Keywords" value="Home Limit 4." />
+   <property name="Keywords" value="Home Limit 3." />
    <property name="Text" value="When you play a card, put a Dragon counter on this card. Then, if there are at least 4 Dragon counters on this card, remove them and turn it over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -3960,26 +3960,26 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="UR" />
-     <alternate name="Spike" type="Mane Character Boosted">
-      <property name="Number" value="CG192" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Honesty" />
-      <property name="Subname" value="The Brave and Glorious" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Dragon" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="If one of your Friends or Resources would be dismissed, you may turn this card over instead. If you do, that card is not dismissed." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="UR" />
-  </alternate>
+   <alternate name="Spike" type="Mane Character Boosted">
+    <property name="Number" value="CG192" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Honesty" />
+    <property name="Subname" value="The Brave and Glorious" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Dragon" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="If one of your Friends or Resources would be dismissed, you may turn this card over instead. If you do, that card is not dismissed." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="UR" />
+   </alternate>
   </card>
   <card id="4c745074-b717-421f-af33-0e01909bd246" name="Spitfire">
    <property name="Number" value="CG193" />
@@ -3991,7 +3991,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Teamwork" />
+   <property name="Keywords" value="Teamwork." />
    <property name="Text" value="During faceoffs involving this card, this card has +1 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -4011,7 +4011,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Teamwork" />
+   <property name="Keywords" value="Teamwork." />
    <property name="Text" value="Faceoff: Exhaust this card to flip an additional card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -4031,7 +4031,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Teamwork" />
+   <property name="Keywords" value="Teamwork." />
    <property name="Text" value="Main Phase: Retire this card to gain control of an opponent's Friend with power less than or equal to this card's power until the end of the Score Phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -4048,7 +4048,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="Subname" value="Distracting Cheerer" />
    <property name="Power" value="3" />
    <property name="Cost" value="3" />
-   <property name="PlayRequiredPower" value="5" />
+   <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
@@ -4090,7 +4090,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="Cost" value="4" />
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Generosity" />
-   <property name="Traits" value="Alicorn, Crystal, Royalty" />
+   <property name="Traits" value="Alicorn, Royalty, Crystal" />
    <property name="Keywords" value="" />
    <property name="Text" value="Troublemakers can't be uncovered here." />
    <property name="ProblemBonus" value="" />
@@ -4111,7 +4111,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Teamwork" />
+   <property name="Keywords" value="Teamwork." />
    <property name="Text" value="When this card enters play at a Problem, you may send it home to put an opponent's Friend there with cost less than or equal to this card's cost into its owner's hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -4132,7 +4132,7 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="During faceoffs involving this card, players flip 1 fewer card." />
+   <property name="Text" value="During faceoffs involving this card, players flip 1 fewer cards." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4171,9 +4171,8 @@ This card can only be challenged by a number of characters up to the number of U
    <property name="PlayRequiredPower" value="5" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Location, Unique" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="At the end of your turn, put a Victory counter on this card.
-At the start of your turn, you may retire this card. If you do, each player puts a number of Friends from their discard pile into play up to the number of Victory counters on this card." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;At the end of your turn, put a Victory counter on this card.&#10;At the start of your turn, you may retire this card. If you do, each player puts a number of Friends from their discard pile into play up to the number of Victory counters on this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4192,11 +4191,8 @@ At the start of your turn, you may retire this card. If you do, each player puts
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Artifact, Unique" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="You must control Applejack to play this card.
-At the start of your turn, put a Harmony count
-er on this card.
-Reaction: After one of your [Honesty] friends enters play, put a number of +1 power counters on it equal to the number of Harmony counters on this card, then remove all Harmony counters from this card." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;You must control Applejack to play this card.&#10;At the start of your turn, put a Harmony counter on this card.&#10;Reaction: After one of your [Honesty] Friends enters play, put a number of +1 power counters on it equal to the number of Harmony counters on this card, then remove all Harmony counters from this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4214,11 +4210,9 @@ Reaction: After one of your [Honesty] friends enters play, put a number of +1 po
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
-   <property name="Traits" value="Artifact, Unique" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="You must control Rarity to play this card.
-At the start of your turn, put a Harmony counter on this card.
-Score Phase: Remove 2 Harmony counters from this card to reduce the confront requirements of a problem by 3 [Any]." />
+   <property name="Traits" value="Unique, Artifact" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;You must control Rarity to play this card.&#10;At the start of your turn, put a Harmony counter on this card.&#10;Score Phase: Remove 2 Harmony counters from this card to reduce the confront requirements of a problem by 3 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4237,29 +4231,9 @@ Score Phase: Remove 2 Harmony counters from this card to reduce the confront req
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Epic" />
-   <property name="Keywords" value="Villain" />
-   <property name="Text" value="When this card is uncovered, you may pay 2. If you do, dismiss each Friend here with cost 2 or less." />
+   <property name="Keywords" value="Villain." />
+   <property name="Text" value="When this card is uncovered, you may pay 2AT. If you do, dismiss each Friend here with cost 2 or less." />
    <property name="ProblemBonus" value="2" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="UR" />
-  </card>
-  <card id="b4b25356-7be9-4a16-b8af-8c4cd6421f02" name="Princess Twilight Sparkle">
-   <property name="Number" value="CG0" />
-   <property name="Type" value="Friend" />
-   <property name="Element" value="Magic" />
-   <property name="Subname" value="Princess of Friendship" />
-   <property name="Power" value="3" />
-   <property name="Cost" value="5" />
-   <property name="PlayRequiredPower" value="3" />
-   <property name="PlayRequiredElement" value="Magic" />
-   <property name="Traits" value="Alicorn, Royalty" />
-   <property name="Keywords" value="Studious, Swift" />
-   <property name="Text" value="When you play this card, gain 1 for each opposing character at this card's Problem." />
-   <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />

--- a/Sets/846578e8-dde2-4348-9477-ef545c662b7f/set.xml
+++ b/Sets/846578e8-dde2-4348-9477-ef545c662b7f/set.xml
@@ -1,88 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<set name="Rock and Rave" id="846578e8-dde2-4348-9477-ef545c662b7f" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="3.1.0.0" version="3.0">
+<set name="Rock and Rave" id="846578e8-dde2-4348-9477-ef545c662b7f" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="2.2.4.4" version="3.1">
  <cards>
-  <card id="662e8937-dffd-4c48-ae9b-a160e8cc6144" name="Maud Pie">
-   <property name="Number" value="rrF1" />
-   <property name="Type" value="Mane Character" />
-   <property name="Element" value="Honesty" />
-   <property name="Subname" value="Rockin'" />
-   <property name="Power" value="1" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="At the end of your Main Phase, if you have a Friend and a Resource, turn this card over." />
-   <property name="ProblemBonus" value="" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="F" />
-     <alternate name="Maud Pie" type="Mane Character Boosted">
-      <property name="Number" value="rrF1" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Honesty" />
-      <property name="Subname" value="Rockin'" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Earth Pony" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="This card has +1 power for each card type in your discard pile." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="F" />
-      </alternate>
-  </card>
-  <card id="251abe9a-f211-4463-b7d0-c10919c8192e" name="DJ Pon-3">
-   <property name="Number" value="rrF2" />
-   <property name="Type" value="Mane Character" />
-   <property name="Element" value="Laughter" />
-   <property name="Subname" value="Party Starter" />
-   <property name="Power" value="1" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="When you draw your third card during a turn, shuffle your deck and turn this card over." />
-   <property name="ProblemBonus" value="" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="F" />
-     <alternate name="DJ Pon-3" type="Mane Character Boosted">
-      <property name="Number" value="rrF2" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Laughter" />
-      <property name="Subname" value="Party Starter" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Unicorn" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="Main Phase: Exhaust this card to draw a card.  At the start of your Score Phase, if this card is with at least 3 of your Friends, you may ready this card." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="F" />
-      </alternate>
-  </card>
   <card id="5ba8e10b-154a-412c-a262-a13caefe3c3c" name="Apple Strudel">
-   <property name="Number" value="rr1" />
+   <property name="Number" value="RR1" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Well Aged" />
@@ -92,7 +12,7 @@
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony, Elder" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: After an opponent moves a character to this card's Problem, you may pay 1 to exhaust that character." />
+   <property name="Text" value="Reaction: After an opponent moves a character to this card's Problem, you may pay 1AT to exhaust that character." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -102,7 +22,7 @@
    <property name="Rarity" value="F" />
   </card>
   <card id="1256f228-d3c7-4d59-bcc9-1d26ef4e6c4d" name="Berry Punch">
-   <property name="Number" value="rr2" />
+   <property name="Number" value="RR2" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="All-Night Partier" />
@@ -112,8 +32,7 @@
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card enters play, you may draw a card.
-When you confront this card's Problem, you may exhaust this card to draw a card." />
+   <property name="Text" value="When this card enters play, you may draw a card.&#10;When you confront this card's Problem, you may exhaust this card to draw a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -123,7 +42,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="464127bc-a809-48ce-a7e6-c7f58499197c" name="Twinkleshine">
-   <property name="Number" value="rr3" />
+   <property name="Number" value="RR3" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Overachiever" />
@@ -143,7 +62,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="d9406f47-dda4-4f84-a36e-ef07f9f235ae" name="Octavia">
-   <property name="Number" value="rr4" />
+   <property name="Number" value="RR4" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Sweet Symphony" />
@@ -163,7 +82,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="ce2c72d5-28e0-4077-b2d9-0709ac15ddf4" name="It's Elementary!">
-   <property name="Number" value="rr5" />
+   <property name="Number" value="RR5" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -183,7 +102,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="e0ad5a37-4089-4d10-857a-344d3a242812" name="Rock Solid Fashion">
-   <property name="Number" value="rr6" />
+   <property name="Number" value="RR6" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -193,7 +112,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Choose a [Generosity] or [Honesty] character.  That character gets +1 [Generosity] and +1 [Honesty] until the end of the phase." />
+   <property name="Text" value="Main Phase: Choose a [Generosity] or [Honesty] character. That character gets +1 [Generosity] and +1 [Honesty] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -203,7 +122,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="32d1dd6b-b047-4555-bff1-64fadf0c5a51" name="Secret Mission">
-   <property name="Number" value="rr7" />
+   <property name="Number" value="RR7" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -213,7 +132,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Players need +1 [Any] to confront this Problem for each of their opponent's Friends here." />
+   <property name="Text" value="Players need +1 power to confront this Problem for each of their opponent's Friends here." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="6" />
    <property name="ProblemPlayerElement1" value="Laughter" />
@@ -223,7 +142,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="e6f2fbcd-6203-47f9-af43-6859b49c67b3" name="Timber!">
-   <property name="Number" value="rr8" />
+   <property name="Number" value="RR8" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -233,7 +152,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="At the start of a Problem faceoff here, each player chooses a character involved in the faceoff.  Those characters have +2 power until the end of the faceoff." />
+   <property name="Text" value="At the start of a Problem faceoff here, each player chooses a character involved in the faceoff. Those characters have +2 power until the end of the faceoff." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="9" />
    <property name="ProblemPlayerElement1" value="Honesty" />
@@ -243,7 +162,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="d67c7284-abe9-4d9b-9563-6de84b3b1c44" name="Trade Dispute">
-   <property name="Number" value="rr9" />
+   <property name="Number" value="RR9" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -253,7 +172,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="The player with the most friends here can't move Friends to this Problem." />
+   <property name="Text" value="The player with the most Friends here can't move Friends to this Problem." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="6" />
    <property name="ProblemPlayerElement1" value="Generosity" />
@@ -263,7 +182,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="98ddb7cb-6827-4615-88cf-61e87a1c1e7b" name="Which Pinkie is Which">
-   <property name="Number" value="rr10" />
+   <property name="Number" value="RR10" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -283,7 +202,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="6b766397-9f34-4f20-a1d0-22a11d92efa4" name="Diamond Dog">
-   <property name="Number" value="rr11" />
+   <property name="Number" value="RR11" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -293,7 +212,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card is defeated, gain 2." />
+   <property name="Text" value="When this card is defeated, gain 2AT." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -303,7 +222,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="Rarity" value="F" />
   </card>
   <card id="469f413c-1f16-4f8f-adb4-83ea4178228f" name="Quarray Eels">
-   <property name="Number" value="rr12" />
+   <property name="Number" value="RR12" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -313,7 +232,7 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Opponents must pay +1 to move a character to this card's Problem." />
+   <property name="Text" value="Opponents must pay +1AT to move a character to this card's Problem." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -321,6 +240,86 @@ When you confront this card's Problem, you may exhaust this card to draw a card.
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
+  </card>
+  <card id="662e8937-dffd-4c48-ae9b-a160e8cc6144" name="Maud Pie">
+   <property name="Number" value="RRf1" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Honesty" />
+   <property name="Subname" value="Rockin'" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Earth Pony" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="At the end of your Main Phase, if you have a Friend and a Resource, turn this card over." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="F" />
+   <alternate name="Maud Pie" type="Mane Character Boosted">
+    <property name="Number" value="RRf1" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Honesty" />
+    <property name="Subname" value="Rockin'" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Earth Pony" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="This card has +1 power for each card type in your discard pile." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
+  </card>
+  <card id="251abe9a-f211-4463-b7d0-c10919c8192e" name="DJ Pon-3">
+   <property name="Number" value="RRf2" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Laughter" />
+   <property name="Subname" value="Party Starter" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Unicorn" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you draw your third card during a turn, shuffle your deck and turn this card over." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="F" />
+   <alternate name="DJ Pon-3" type="Mane Character Boosted">
+    <property name="Number" value="RRf2" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Laughter" />
+    <property name="Subname" value="Party Starter" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Unicorn" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="Main Phase: Exhaust this card to draw a card.&#10;At the start of your Score Phase, if this card is with at least 3 of your Friends, you may ready this card." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
  </cards>
 </set>

--- a/Sets/b802269c-53a5-4ade-97fc-d08e7cd2dc41/set.xml
+++ b/Sets/b802269c-53a5-4ade-97fc-d08e7cd2dc41/set.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<set name="Celestial Solstice" id="b802269c-53a5-4ade-97fc-d08e7cd2dc41" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="3.1.0.0" version="3.0">
+<set name="Celestial Solstice" id="b802269c-53a5-4ade-97fc-d08e7cd2dc41" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="2.2.4.4" version="3.1">
  <cards>
   <card id="f452c955-8566-41e9-9ccc-4aaa93e4645c" name="Applejack">
-   <property name="Number" value="cs1" />
+   <property name="Number" value="CS1" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Summer Sun Caterer" />
@@ -12,17 +12,17 @@
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Problem Faceoff: Discard a card to give another character +1 power until the end of the faceoff" />
+   <property name="Text" value="Problem Faceoff: Discard a card to give another character +1 power until the end of the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="97648667-dbc1-46b7-965d-05e78bb365f7" name="Princess Luna">
-   <property name="Number" value="cs2" />
+   <property name="Number" value="CS2" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="The Setting Moon" />
@@ -32,17 +32,17 @@
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Alicorn, Royalty" />
    <property name="Keywords" value="" />
-   <property name="Text" value="If you would draw a card during a Main Phase, you may exhaust one of your Friends to gain 1 instead." />
+   <property name="Text" value="If you would draw a card during a Main Phase, you may exhaust one of your Friends to gain 1AT instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="d11227ca-188c-4989-bc84-34ce2491ff7b" name="Rarity">
-   <property name="Number" value="cs3" />
+   <property name="Number" value="CS3" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Mare of Action" />
@@ -59,10 +59,10 @@
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="806e90c9-2cb5-4caa-9741-6c6237890fbe" name="Princess Celestia">
-   <property name="Number" value="cs4" />
+   <property name="Number" value="CS4" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="The Rising Sun" />
@@ -72,17 +72,17 @@
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Alicorn, Royalty" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play a friend, you may draw a card." />
+   <property name="Text" value="When you play a Friend, you may draw a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="fdc6880e-2374-4ecb-9289-f5e7a3e495ed" name="Ten. Seconds. Flat.">
-   <property name="Number" value="cs5" />
+   <property name="Number" value="CS5" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -99,10 +99,10 @@
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="f3e99d4e-f5b5-4b7a-97b8-fc2fe5cf7272" name="Surprise Party!">
-   <property name="Number" value="cs6" />
+   <property name="Number" value="CS6" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -110,19 +110,19 @@
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Laughter" />
-   <property name="Traits" value="Artifact, Unique" />
+   <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: All players shuffle their hands into theird decks and draw 6 cards." />
+   <property name="Text" value="Main Phase: All players shuffle their hands into their decks and draw six cards." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="f558b730-0ef5-4b43-9168-20411b6c8baf" name="Tree of Harmony">
-   <property name="Number" value="cs7" />
+   <property name="Number" value="CS7" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="Seeds of Friendship" />
@@ -130,21 +130,19 @@
    <property name="Cost" value="3" />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="" />
+   <property name="Traits" value="Artifact, Unique" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Play to your home.
-Main Phase: Exhaust this card and one of your Friends to put a Harmony counter on this card.
-Main Phase: Retire this card to gain a number of action tokens equal to the number of Harmony counters on it." />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and one of your Friends to put a Harmony counter on this card.&#10;Main Phase: Retire this card to gain a number of action tokens equal to the number of Harmony counters on it." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="0457fd69-edfd-4900-87f8-342f7788e301" name="Nightmare Moon">
-   <property name="Number" value="cs8" />
+   <property name="Number" value="CS8" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="New Moon" />
@@ -154,17 +152,17 @@ Main Phase: Retire this card to gain a number of action tokens equal to the numb
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card is defeated, you may search your deck for an [Alicorn] Friend, reveal it, put it into play, and shuffle your deck." />
+   <property name="Text" value="When this card is defeated, you may search your deck for an Alicorn Friend, reveal it, put it into play, and shuffle your deck." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
+   <property name="Rarity" value="F" />
   </card>
   <card id="18ddad42-57a8-43e5-9036-80154e2485b4" name="Twilight Sparkle">
-   <property name="Number" value="csF1" />
+   <property name="Number" value="CSf1" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Friendship is Magic" />
@@ -174,37 +172,37 @@ Main Phase: Retire this card to gain a number of action tokens equal to the numb
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="When you play a Friend that isa different color from one of your other Friends, turn this card over." />
+   <property name="Text" value="When you play a Friend that is a different color from one of your other Friends, turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
-     <alternate name="Twilight Sparkle" type="Mane Character Boosted">
-      <property name="Number" value="csF1" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Magic" />
-      <property name="Subname" value="Friendship is Magic" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Unicorn" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="When this side of the card is turned face up, choose a color for each of your opponents. This card gains each of those colors" />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="P" />
-      </alternate>
+   <property name="Rarity" value="F" />
+   <alternate name="Twilight Sparkle" type="Mane Character Boosted">
+    <property name="Number" value="CSf1" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Magic" />
+    <property name="Subname" value="Friendship is Magic" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Unicorn" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="When this side of the card is turned face up, choose a color for each of your opponents. This card gains each of those colors." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
   <card id="06cd2929-5343-4328-98da-09805fb40ce3" name="Princess Celestia">
-   <property name="Number" value="csF2" />
+   <property name="Number" value="CSf2" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Solar Sister" />
@@ -214,34 +212,34 @@ Main Phase: Retire this card to gain a number of action tokens equal to the numb
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Alicorn, Royalty" />
    <property name="Keywords" value="Home Limit 3." />
-   <property name="Text" value="When one of you [Alicorn] Friends enters play, if you have at least 1 other [Alicorn] Friend, turn this card over." />
+   <property name="Text" value="When one of your Alicorn Friends enters play, if you have at least 1 other Alicorn Friend, turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="P" />
-     <alternate name="Princess Celestia" type="Mane Character Boosted">
-      <property name="Number" value="csF2" />
-      <property name="Type" value="Mane Character Boosted" />
-      <property name="Element" value="Kindness" />
-      <property name="Subname" value="Solar Sister" />
-      <property name="Power" value="3" />
-      <property name="Cost" value="" />
-      <property name="PlayRequiredPower" value="" />
-      <property name="PlayRequiredElement" value="" />
-      <property name="Traits" value="Alicorn, Royalty" />
-      <property name="Keywords" value="Home Limit 4." />
-      <property name="Text" value="While you have Princess Luna, Princess Twilight Sparkle, or Princess Cadence, each of your [Alicorn] Friends has +1 power." />
-      <property name="ProblemBonus" value="" />
-      <property name="ProblemOpponentPower" value="" />
-      <property name="ProblemPlayerElement1" value="" />
-      <property name="ProblemPlayerElement1Power" value="" />
-      <property name="ProblemPlayerElement2" value="" />
-      <property name="ProblemPlayerElement2Power" value="" />
-      <property name="Rarity" value="P" />
-      </alternate>
+   <property name="Rarity" value="F" />
+   <alternate name="Princess Celestia" type="Mane Character Boosted">
+    <property name="Number" value="CSf2" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Kindness" />
+    <property name="Subname" value="Solar Sister" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Alicorn, Royalty" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="While you have Princess Luna, Princess Twilight Sparkle, or Princess Cadance, each of your Alicorn Friends has +1 power." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
   </card>
  </cards>
 </set>

--- a/Sets/c0a7fe94-f958-4eb6-92e9-97dffb315e58/set.xml
+++ b/Sets/c0a7fe94-f958-4eb6-92e9-97dffb315e58/set.xml
@@ -1,8 +1,28 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<set name="Canterlot Nights" id="c0a7fe94-f958-4eb6-92e9-97dffb315e58" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="3.1.0.0" version="3.0">
+<set name="Canterlot Nights" id="c0a7fe94-f958-4eb6-92e9-97dffb315e58" gameId="65656467-b709-43b2-a5c6-80c2f216adf9" gameVersion="2.2.4.4" version="3.1">
  <cards>
-   <card id="ad7f8550-7a8c-414e-b96c-6c99c8f925e5" name="Rainbow Dash">
-   <property name="Number" value="cn1" />
+  <card id="43f49090-675d-48a1-8af2-1efbe5be5c1f" name="Flutterbat">
+   <property name="Number" value="CN0" />
+   <property name="Type" value="Troublemaker" />
+   <property name="Element" value="" />
+   <property name="Subname" value="" />
+   <property name="Power" value="5" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="When this card is uncovered, move it to another Problem.&#10;At the start of your opponent's Troublemaker Phase, move this card to a Problem with a number of characters equal to or less than the number of characters at this card's Problem." />
+   <property name="ProblemBonus" value="2" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="UR" />
+  </card>
+  <card id="ad7f8550-7a8c-414e-b96c-6c99c8f925e5" name="Rainbow Dash">
+   <property name="Number" value="CN1" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Hanging Out" />
@@ -11,8 +31,8 @@
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Home Limit 3" />
-   <property name="Text" value="While there are at least 2 [Pegasus] Friends at this card's Problem, you may turn this card over." />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="Any Phase: While there are at least 2 Pegasus Friends at this card's Problem, you may turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -20,29 +40,29 @@
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="U" />
-      <alternate name="Rainbow Dash" type="Mane Character Boosted">
-       <property name="Number" value="cn1" />
-       <property name="Type" value="Mane Character Boosted" />
-       <property name="Element" value="Loyalty" />
-       <property name="Subname" value="Hanging Out" />
-       <property name="Power" value="3" />
-       <property name="Cost" value="" />
-       <property name="PlayRequiredPower" value="" />
-       <property name="PlayRequiredElement" value="" />
-       <property name="Traits" value="Pegasus" />
-       <property name="Keywords" value="Home Limit 4, Swift" />
-       <property name="Text" value="At the start of a faceoff involving this card, you may ready an exhausted Friend at this card's Problem." />
-       <property name="ProblemBonus" value="" />
-       <property name="ProblemOpponentPower" value="" />
-       <property name="ProblemPlayerElement1" value="" />
-       <property name="ProblemPlayerElement1Power" value="" />
-       <property name="ProblemPlayerElement2" value="" />
-       <property name="ProblemPlayerElement2Power" value="" />
-       <property name="Rarity" value="U" />
-   	</alternate>
+   <alternate name="Rainbow Dash" type="Mane Character Boosted">
+    <property name="Number" value="CN1" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Loyalty" />
+    <property name="Subname" value="Hanging Out" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Pegasus" />
+    <property name="Keywords" value="Home Limit 4, Swift." />
+    <property name="Text" value="At the start of a faceoff involving this card, you may ready an exhausted Friend at this card's Problem." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="U" />
+   </alternate>
   </card>
   <card id="dd658570-40f1-46ca-b612-c6de9a49b5ff" name="Applejack">
-   <property name="Number" value="cn2" />
+   <property name="Number" value="CN2" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Apple Vendor" />
@@ -51,9 +71,8 @@
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Home Limit 3" />
-   <property name="Text" value="At the start of your Score Phase, you may pay 2 to give one of your Friends +2 power until the end of the turn.
-At the end of your turn, if you have a Friend with at least 5 power, turn this card over." />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="At the start of your Score Phase, you may pay 2AT to give one of your Friends +2 power until the end of turn.&#10;At the end of your turn, if you have a Friend with at least 5 power, turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -61,109 +80,29 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="U" />
-      <alternate name="Applejack" type="Mane Character Boosted">
-       <property name="Number" value="cn2" />
-       <property name="Type" value="Mane Character Boosted" />
-       <property name="Element" value="Honesty" />
-       <property name="Subname" value="Apple Vendor" />
-       <property name="Power" value="3" />
-       <property name="Cost" value="" />
-       <property name="PlayRequiredPower" value="" />
-       <property name="PlayRequiredElement" value="" />
-       <property name="Traits" value="Earth Pony" />
-       <property name="Keywords" value="Home Limit 4, Stubborn" />
-       <property name="Text" value="Main Phase: Retire one of your Friends to reveal the top 3 cards of your deck, put a revealed Friend into your hand, and put all other revealed cards into your discard pile." />
-       <property name="ProblemBonus" value="" />
-       <property name="ProblemOpponentPower" value="" />
-       <property name="ProblemPlayerElement1" value="" />
-       <property name="ProblemPlayerElement1Power" value="" />
-       <property name="ProblemPlayerElement2" value="" />
-       <property name="ProblemPlayerElement2Power" value="" />
-       <property name="Rarity" value="U" />
-   </alternate>
-  </card>
-  <card id="2b501334-bb56-43c3-a409-bf7d4cca31a6" name="Pinkie Pie">
-   <property name="Number" value="cn3" />
-   <property name="Type" value="Mane Character" />
-   <property name="Element" value="Laughter" />
-   <property name="Subname" value="Poney Pokey" />
-   <property name="Power" value="1" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Home Limit 3" />
-   <property name="Text" value="When you end your turn, if this card is at home or a Problem with at least 3 of your Friends, turn it over." />
-   <property name="ProblemBonus" value="" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="U" />
-      <alternate name="Pinkie Pie" type="Mane Character Boosted">
-       <property name="Number" value="cn3" />
-       <property name="Type" value="Mane Character Boosted" />
-       <property name="Element" value="Laughter" />
-       <property name="Subname" value="Poney Pokey" />
-       <property name="Power" value="3" />
-       <property name="Cost" value="" />
-       <property name="PlayRequiredPower" value="" />
-       <property name="PlayRequiredElement" value="" />
-       <property name="Traits" value="Earth Pony" />
-       <property name="Keywords" value="Home Limit 4, Random" />
-       <property name="Text" value="When you confront this card's Problem, you may retire one of your Friends there to dismiss an opponent's Friend there." />
-       <property name="ProblemBonus" value="" />
-       <property name="ProblemOpponentPower" value="" />
-       <property name="ProblemPlayerElement1" value="" />
-       <property name="ProblemPlayerElement1Power" value="" />
-       <property name="ProblemPlayerElement2" value="" />
-       <property name="ProblemPlayerElement2Power" value="" />
-       <property name="Rarity" value="U" />
-   </alternate>
-  </card>
-  <card id="b8e20a51-a782-44f9-b07e-45b41e4d3d8c" name="Princess Luna">
-     <property name="Number" value="cn4" />
-     <property name="Type" value="Mane Character" />
-     <property name="Element" value="Magic" />
-     <property name="Subname" value="The Party's Over" />
-     <property name="Power" value="1" />
-     <property name="Cost" value="" />
-     <property name="PlayRequiredPower" value="" />
-     <property name="PlayRequiredElement" value="" />
-     <property name="Traits" value="Alicorn, Royalty" />
-     <property name="Keywords" value="Home Limit 3" />
-     <property name="Text" value="When you win a faceoff involving this card, turn this card over." />
-     <property name="ProblemBonus" value="" />
-     <property name="ProblemOpponentPower" value="" />
-     <property name="ProblemPlayerElement1" value="" />
-     <property name="ProblemPlayerElement1Power" value="" />
-     <property name="ProblemPlayerElement2" value="" />
-     <property name="ProblemPlayerElement2Power" value="" />
-     <property name="Rarity" value="U" />
-       <alternate name="Princess Luna" type="Mane Character Boosted">
-        <property name="Number" value="cn4" />
-        <property name="Type" value="Mane Character Boosted" />
-        <property name="Element" value="Magic" />
-        <property name="Subname" value="The Party's Over" />
-        <property name="Power" value="3" />
-        <property name="Cost" value="" />
-        <property name="PlayRequiredPower" value="" />
-        <property name="PlayRequiredElement" value="" />
-        <property name="Traits" value="Alicorn, Royalty" />
-        <property name="Keywords" value="Home Limit 4" />
-        <property name="Text" value="Opposing characters here have -1 power during Problem faceoffs." />
-        <property name="ProblemBonus" value="" />
-        <property name="ProblemOpponentPower" value="" />
-        <property name="ProblemPlayerElement1" value="" />
-        <property name="ProblemPlayerElement1Power" value="" />
-        <property name="ProblemPlayerElement2" value="" />
-        <property name="ProblemPlayerElement2Power" value="" />
-        <property name="Rarity" value="U" />
+   <alternate name="Applejack" type="Mane Character Boosted">
+    <property name="Number" value="CN2" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Honesty" />
+    <property name="Subname" value="Apple Vendor" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Earth Pony" />
+    <property name="Keywords" value="Home Limit 4, Stubborn." />
+    <property name="Text" value="Main Phase: Retire one of your Friends to reveal the top 3 cards of your deck, put a revealed Friend into your hand, and put all other revealed cards into your discard pile." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="U" />
    </alternate>
   </card>
   <card id="38684cc8-425e-4143-9341-eb7f7b69fb54" name="Princess Luna">
-   <property name="Number" value="cnf4" />
+   <property name="Number" value="CNf2" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Princess of the Night" />
@@ -172,8 +111,48 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Alicorn, Royalty" />
-   <property name="Keywords" value="Home Limit 3" />
-   <property name="Text" value="When you confront this card's Problem, you may pay 2 to turn this card over." />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you confront this card's Problem, you may pay 2AT to turn this card over." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="F" />
+   <alternate name="Princess Luna" type="Mane Character Boosted">
+    <property name="Number" value="CNf2" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Magic" />
+    <property name="Subname" value="Princess of the Night" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Alicorn, Royalty" />
+    <property name="Keywords" value="Home Limit 4, Studious." />
+    <property name="Text" value="Faceoff: Discard an Event to give this card +3 power until the end of the faceoff." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
+  </card>
+  <card id="2b501334-bb56-43c3-a409-bf7d4cca31a6" name="Pinkie Pie">
+   <property name="Number" value="CN3" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Laughter" />
+   <property name="Subname" value="Pokey Pony" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Earth Pony" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you end your turn, if this card is at home or a Problem with at least 3 of your Friends, turn it over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -181,39 +160,39 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="U" />
-      <alternate name="Princess Luna" type="Mane Character Boosted">
-       <property name="Number" value="cnf4" />
-       <property name="Type" value="Mane Character Boosted" />
-       <property name="Element" value="Magic" />
-       <property name="Subname" value="Princess of the Night" />
-       <property name="Power" value="3" />
-       <property name="Cost" value="" />
-       <property name="PlayRequiredPower" value="" />
-       <property name="PlayRequiredElement" value="" />
-       <property name="Traits" value="Alicorn, Royalty" />
-       <property name="Keywords" value="Home Limit 4, Studious" />
-       <property name="Text" value="Faceoff: Discard an Event to give this card +3 power until the end of the faceoff." />
-       <property name="ProblemBonus" value="" />
-       <property name="ProblemOpponentPower" value="" />
-       <property name="ProblemPlayerElement1" value="" />
-       <property name="ProblemPlayerElement1Power" value="" />
-       <property name="ProblemPlayerElement2" value="" />
-       <property name="ProblemPlayerElement2Power" value="" />
-       <property name="Rarity" value="U" />
+   <alternate name="Pinkie Pie" type="Mane Character Boosted">
+    <property name="Number" value="CN3" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Laughter" />
+    <property name="Subname" value="Pokey Pony" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Earth Pony" />
+    <property name="Keywords" value="Home Limit 4, Random." />
+    <property name="Text" value="When you confront this card's Problem, you may retire one of your Friends there to dismiss an opponent's Friend there." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="U" />
    </alternate>
   </card>
-  <card id="b10cd7cf-a119-4a16-87a5-2413c2ed892b" name="Twilight Sparkle">
-   <property name="Number" value="cn5" />
+  <card id="b8e20a51-a782-44f9-b07e-45b41e4d3d8c" name="Princess Luna">
+   <property name="Number" value="CN4" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Magic" />
-   <property name="Subname" value="Gala Greeter" />
+   <property name="Subname" value="The Party's Over" />
    <property name="Power" value="1" />
    <property name="Cost" value="" />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Home Limit 3" />
-   <property name="Text" value="When you play an Event, turn this card over and exhaust it." />
+   <property name="Traits" value="Alicorn, Royalty" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you win a faceoff involving this card, turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -221,149 +200,29 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="U" />
-      <alternate name="Twilight Sparkle" type="Mane Character Boosted">
-       <property name="Number" value="cn5" />
-       <property name="Type" value="Mane Character Boosted" />
-       <property name="Element" value="Magic" />
-       <property name="Subname" value="Gala Greeter" />
-       <property name="Power" value="3" />
-       <property name="Cost" value="" />
-       <property name="PlayRequiredPower" value="" />
-       <property name="PlayRequiredElement" value="" />
-       <property name="Traits" value="Unicorn" />
-       <property name="Keywords" value="Home Limit 4, Studious" />
-       <property name="Text" value="When you move this card to a Problem, you may move an opponent's Friend to that problem." />
-       <property name="ProblemBonus" value="" />
-       <property name="ProblemOpponentPower" value="" />
-       <property name="ProblemPlayerElement1" value="" />
-       <property name="ProblemPlayerElement1Power" value="" />
-       <property name="ProblemPlayerElement2" value="" />
-       <property name="ProblemPlayerElement2Power" value="" />
-       <property name="Rarity" value="U" />
-   </alternate>
-  </card>
-  <card id="af3437a7-12f8-4608-a75e-881ae0de8c8f" name="Rarity">
-   <property name="Number" value="cn6" />
-   <property name="Type" value="Mane Character" />
-   <property name="Element" value="Generosity" />
-   <property name="Subname" value="Dressmaker" />
-   <property name="Power" value="1" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Home Limit 3" />
-   <property name="Text" value="When you play a Resource on one of your Friends, turn this card over." />
-   <property name="ProblemBonus" value="" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="U" />
-      <alternate name="Rarity" type="Mane Character Boosted">
-       <property name="Number" value="cn6" />
-       <property name="Type" value="Mane Character Boosted" />
-       <property name="Element" value="Generosity" />
-       <property name="Subname" value="Dressmaker" />
-       <property name="Power" value="3" />
-       <property name="Cost" value="" />
-       <property name="PlayRequiredPower" value="" />
-       <property name="PlayRequiredElement" value="" />
-       <property name="Traits" value="Unicorn" />
-       <property name="Keywords" value="Home Limit 4, Inspired." />
-       <property name="Text" value="When you play a Resource on one of your Friends, that Friend gets +2 power until the end of the turn." />
-       <property name="ProblemBonus" value="" />
-       <property name="ProblemOpponentPower" value="" />
-       <property name="ProblemPlayerElement1" value="" />
-       <property name="ProblemPlayerElement1Power" value="" />
-       <property name="ProblemPlayerElement2" value="" />
-       <property name="ProblemPlayerElement2Power" value="" />
-       <property name="Rarity" value="U" />
-   </alternate>
-  </card>
-  <card id="fb3664df-82f9-42b7-91f4-5f4dc000bd34" name="Fluttershy">
-   <property name="Number" value="cn7" />
-   <property name="Type" value="Mane Character" />
-   <property name="Element" value="Kindness" />
-   <property name="Subname" value="Friend to Animals" />
-   <property name="Power" value="1" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Home Limit 3" />
-   <property name="Text" value="Pay 3 to turn this card over. You pay 1 less action token to turn this card over for each [Critter] Friend you control." />
-   <property name="ProblemBonus" value="" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="U" />
-      <alternate name="Fluttershy" type="Mane Character Boosted">
-       <property name="Number" value="cn7" />
-       <property name="Type" value="Mane Character Boosted" />
-       <property name="Element" value="Kindness" />
-       <property name="Subname" value="Friend to Animals" />
-       <property name="Power" value="3" />
-       <property name="Cost" value="" />
-       <property name="PlayRequiredPower" value="" />
-       <property name="PlayRequiredElement" value="" />
-       <property name="Traits" value="Pegasus" />
-       <property name="Keywords" value="Home Limit 4, Caretaker" />
-       <property name="Text" value="Main Phase: Pay 1 to move this card to a Problem that has one of your [Critter] Friends there." />
-       <property name="ProblemBonus" value="" />
-       <property name="ProblemOpponentPower" value="" />
-       <property name="ProblemPlayerElement1" value="" />
-       <property name="ProblemPlayerElement1Power" value="" />
-       <property name="ProblemPlayerElement2" value="" />
-       <property name="ProblemPlayerElement2Power" value="" />
-       <property name="Rarity" value="U" />
-   </alternate>
-  </card>
-  <card id="2c19775b-672c-4fd8-9f2f-8f7da5b996f0" name="Rarity">
-     <property name="Number" value="cn8" />
-     <property name="Type" value="Mane Character" />
-     <property name="Element" value="Generosity" />
-     <property name="Subname" value="Mover and Shaker" />
-     <property name="Power" value="1" />
-     <property name="Cost" value="" />
-     <property name="PlayRequiredPower" value="" />
-     <property name="PlayRequiredElement" value="" />
-     <property name="Traits" value="Unicorn" />
-     <property name="Keywords" value="Home Limit 3" />
-     <property name="Text" value="When you confront this card's Problem with at least 2 other [Generosity] characters, turn this card over." />
-     <property name="ProblemBonus" value="" />
-     <property name="ProblemOpponentPower" value="" />
-     <property name="ProblemPlayerElement1" value="" />
-     <property name="ProblemPlayerElement1Power" value="" />
-     <property name="ProblemPlayerElement2" value="" />
-     <property name="ProblemPlayerElement2Power" value="" />
-     <property name="Rarity" value="U" />
-      <alternate name="Rarity" type="Mane Character Boosted">
-	     <property name="Number" value="cn8" />
-	     <property name="Type" value="Mane Character Boosted" />
-	     <property name="Element" value="Generosity" />
-	     <property name="Subname" value="Mover and Shaker" />
-	     <property name="Power" value="3" />
-	     <property name="Cost" value="" />
-	     <property name="PlayRequiredPower" value="" />
-	     <property name="PlayRequiredElement" value="" />
-	     <property name="Traits" value="Unicorn" />
-	     <property name="Keywords" value="Home Limit 4" />
-	     <property name="Text" value="Your opponent pays +1 to play Events." />
-	     <property name="ProblemBonus" value="" />
-	     <property name="ProblemOpponentPower" value="" />
-	     <property name="ProblemPlayerElement1" value="" />
-	     <property name="ProblemPlayerElement1Power" value="" />
-	     <property name="ProblemPlayerElement2" value="" />
-	     <property name="ProblemPlayerElement2Power" value="" />
-	     <property name="Rarity" value="U" />
+   <alternate name="Princess Luna" type="Mane Character Boosted">
+    <property name="Number" value="CN4" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Magic" />
+    <property name="Subname" value="The Party's Over" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Alicorn, Royalty" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="Opposing characters here have -1 power during Problem faceoffs." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="U" />
    </alternate>
   </card>
   <card id="b3004b95-f605-4614-8147-ad9869b0314c" name="Princess Celestia">
-   <property name="Number" value="cnf8" />
+   <property name="Number" value="CNf4" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Hoof Shaker" />
@@ -372,7 +231,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Alicorn, Royalty" />
-   <property name="Keywords" value="Home Limit 3" />
+   <property name="Keywords" value="Home Limit 3." />
    <property name="Text" value="Main Phase: Exhaust 3 of your Friends to turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -380,30 +239,190 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="F" />
+   <alternate name="Princess Celestia" type="Mane Character Boosted">
+    <property name="Number" value="CNf4" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Kindness" />
+    <property name="Subname" value="Hoof Shaker" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Alicorn, Royalty" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="At the end of your turn, if you have Friends at home in excess of your home limit, you may exhaust this card to put a Friend there into your hand." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="F" />
+   </alternate>
+  </card>
+  <card id="b10cd7cf-a119-4a16-87a5-2413c2ed892b" name="Twilight Sparkle">
+   <property name="Number" value="CN5" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Magic" />
+   <property name="Subname" value="Gala Greeter" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Unicorn" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you play an Event, turn this card over and exhaust it." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="U" />
-      <alternate name="Princess Celestia" type="Mane Character Boosted">
-       <property name="Number" value="cnf8" />
-       <property name="Type" value="Mane Character Boosted" />
-       <property name="Element" value="Kindness" />
-       <property name="Subname" value="Hoof Shaker" />
-       <property name="Power" value="3" />
-       <property name="Cost" value="" />
-       <property name="PlayRequiredPower" value="" />
-       <property name="PlayRequiredElement" value="" />
-       <property name="Traits" value="Alicorn, Royalty" />
-       <property name="Keywords" value="Home Limit 4" />
-       <property name="Text" value="If one of your Friends would be dismissed for being in excess of your home limit, you may exhaust this card to put that Friend in your hand instead." />
-       <property name="ProblemBonus" value="" />
-       <property name="ProblemOpponentPower" value="" />
-       <property name="ProblemPlayerElement1" value="" />
-       <property name="ProblemPlayerElement1Power" value="" />
-       <property name="ProblemPlayerElement2" value="" />
-       <property name="ProblemPlayerElement2Power" value="" />
-       <property name="Rarity" value="U" />
+   <alternate name="Twilight Sparkle" type="Mane Character Boosted">
+    <property name="Number" value="CN5" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Magic" />
+    <property name="Subname" value="Gala Greeter" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Unicorn" />
+    <property name="Keywords" value="Home Limit 4, Studious." />
+    <property name="Text" value="When you move this card to a Problem, you may move an opponent's Friend to that Problem." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="U" />
+   </alternate>
+  </card>
+  <card id="af3437a7-12f8-4608-a75e-881ae0de8c8f" name="Rarity">
+   <property name="Number" value="CN6" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Generosity" />
+   <property name="Subname" value="Dressmaker" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Unicorn" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you play a Resource on one of your Friends, turn this card over." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="U" />
+   <alternate name="Rarity" type="Mane Character Boosted">
+    <property name="Number" value="CN6" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Generosity" />
+    <property name="Subname" value="Dressmaker" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Unicorn" />
+    <property name="Keywords" value="Home Limit 4, Inspired." />
+    <property name="Text" value="When you play a Resource on one of your Friends, that Friend gets +2 power until the end of the turn." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="U" />
+   </alternate>
+  </card>
+  <card id="fb3664df-82f9-42b7-91f4-5f4dc000bd34" name="Fluttershy">
+   <property name="Number" value="CN7" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Kindness" />
+   <property name="Subname" value="Friend to Animals" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Pegasus" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="Main Phase: Pay 3AT to turn this card over.&#10;You pay 1 less action token to turn this card over for each Critter Friend you control." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="U" />
+   <alternate name="Fluttershy" type="Mane Character Boosted">
+    <property name="Number" value="CN7" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Kindness" />
+    <property name="Subname" value="Friend to Animals" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Pegasus" />
+    <property name="Keywords" value="Home Limit 4, Caretaker." />
+    <property name="Text" value="Main Phase: Pay 1AT to move this card to a Problem that has one of your Critter Friends there." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="U" />
+   </alternate>
+  </card>
+  <card id="2c19775b-672c-4fd8-9f2f-8f7da5b996f0" name="Rarity">
+   <property name="Number" value="CN8" />
+   <property name="Type" value="Mane Character" />
+   <property name="Element" value="Generosity" />
+   <property name="Subname" value="Mover and Shaker" />
+   <property name="Power" value="1" />
+   <property name="Cost" value="" />
+   <property name="PlayRequiredPower" value="" />
+   <property name="PlayRequiredElement" value="" />
+   <property name="Traits" value="Unicorn" />
+   <property name="Keywords" value="Home Limit 3." />
+   <property name="Text" value="When you confront this card's Problem with at least 2 other [Generosity] characters, turn this card over." />
+   <property name="ProblemBonus" value="" />
+   <property name="ProblemOpponentPower" value="" />
+   <property name="ProblemPlayerElement1" value="" />
+   <property name="ProblemPlayerElement1Power" value="" />
+   <property name="ProblemPlayerElement2" value="" />
+   <property name="ProblemPlayerElement2Power" value="" />
+   <property name="Rarity" value="U" />
+   <alternate name="Rarity" type="Mane Character Boosted">
+    <property name="Number" value="CN8" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Generosity" />
+    <property name="Subname" value="Mover and Shaker" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Unicorn" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="Your opponent pays +1AT to play Events." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="U" />
    </alternate>
   </card>
   <card id="2a59bc09-47f0-4e82-ac94-10f54294c963" name="Chief Thunderhooves">
-   <property name="Number" value="cn9" />
+   <property name="Number" value="CN9" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Buffaloing Buffalo" />
@@ -412,7 +431,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Buffalo" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Reaction: After an opponent plays a Friend to this card's Problem, you may spend a card from beneath this card to frighten that Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -423,7 +442,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="R" />
   </card>
   <card id="aadf8384-6403-4a5f-aff3-9948ff20ebdc" name="Cipher Splash">
-   <property name="Number" value="cn10" />
+   <property name="Number" value="CN10" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Born Ready" />
@@ -432,7 +451,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="At the start of each player's turn, if this card has at least 1 card beneath it, you may ready it." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -443,7 +462,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="U" />
   </card>
   <card id="a05ed997-a22f-4694-b295-ff1f58105105" name="Dark Moon">
-   <property name="Number" value="cn11" />
+   <property name="Number" value="CN11" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Moonlit Colt" />
@@ -463,7 +482,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="C" />
   </card>
   <card id="9d848de0-a9c3-4f4e-9530-a54d1890b260" name="Dr. Hooves">
-   <property name="Number" value="cn12" />
+   <property name="Number" value="CN12" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Just In Time" />
@@ -482,8 +501,8 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="R" />
   </card>
-  <card id="5fbe8f01-d596-4ec5-9fb0-65949aacd34a" name="Eclair Creme">
-   <property name="Number" value="cn13" />
+  <card id="5fbe8f01-d596-4ec5-9fb0-65949aacd34a" name="Eclair Crème">
+   <property name="Number" value="CN13" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Vicarious Listener" />
@@ -493,7 +512,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Score Phase: Exhaust another one of your friends and pay 1 to give this card +2 power until the end of the phase." />
+   <property name="Text" value="Score Phase: Exhaust another one of your Friends and pay 1AT to give this card +2 power until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -502,17 +521,17 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="F" />
   </card>
-  <card id="6dd2de1a-3bd7-4515-a678-4138a70e8fbe" name="Hairpin">
-   <property name="Number" value="cn14" />
+  <card id="6dd2de1a-3bd7-4515-a678-4138a70e8fbe" name="Hairpin Turn">
+   <property name="Number" value="CN14" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
-   <property name="Subname" value="Turn Blocker" />
+   <property name="Subname" value="Blocker" />
    <property name="Power" value="2" />
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Earth Pony, Foal" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="While involved in a faceoff, this card has +2 power for each card beneath it." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -523,7 +542,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="C" />
   </card>
   <card id="7d6b2b25-417b-490e-9d4d-628ba0a1e839" name="Orange Swirl">
-   <property name="Number" value="cn15" />
+   <property name="Number" value="CN15" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Dizzy Daredevil" />
@@ -543,7 +562,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="C" />
   </card>
   <card id="fed2e4f8-b1ba-4a79-99d2-83cc4823f4e3" name="Pipsqueak">
-   <property name="Number" value="cn16" />
+   <property name="Number" value="CN16" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Scrappy Squirt" />
@@ -553,7 +572,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Earth Pony, Foal" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: When an opponent's Troublemaker is uncovered at this card's Problem, you may challenge that Troublemaker with all your characters there." />
+   <property name="Text" value="Reaction: After an opponent's Troublemaker is uncovered at this card's Problem, you may challenge that Troublemaker with all your characters there." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -563,7 +582,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="R" />
   </card>
   <card id="d5570230-776f-4fb5-b9b0-963ac145de22" name="Rainbow Blaze">
-   <property name="Number" value="cn17" />
+   <property name="Number" value="CN17" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Dashing Mentor" />
@@ -572,7 +591,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Supportive 2" />
+   <property name="Keywords" value="Supportive 2." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -583,7 +602,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="C" />
   </card>
   <card id="612d13d9-4fba-48b3-a152-8d99d5299e1f" name="Rainbow Dash">
-   <property name="Number" value="cn18" />
+   <property name="Number" value="CN18" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Goosebump Giver" />
@@ -603,7 +622,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="C" />
   </card>
   <card id="8357131c-0082-4c14-bee6-6dc58219035b" name="Rainbow Dash">
-   <property name="Number" value="cn19" />
+   <property name="Number" value="CN19" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Element of Loyalty" />
@@ -613,7 +632,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus, Unique" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: After an opponent takes an action during their Main Phase, you may pay 1 to move this card." />
+   <property name="Text" value="Reaction: After an opponent takes an action during their Main Phase, you may pay 1AT to move this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -623,7 +642,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="R" />
   </card>
   <card id="54f09367-d3f4-40d1-83b4-80047c26f47c" name="Rumble">
-   <property name="Number" value="cn20" />
+   <property name="Number" value="CN20" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Fast Learner" />
@@ -643,17 +662,17 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="C" />
   </card>
   <card id="9c65932c-33eb-4351-b464-1bcc0043c020" name="Scootaloo">
-   <property name="Number" value="cn21" />
+   <property name="Number" value="CN21" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
-   <property name="Subname" value="Fan Club Leader" />
+   <property name="Subname" value="Fan Club Founder" />
    <property name="Power" value="2" />
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus, Foal" />
-   <property name="Keywords" value="Supportive 1" />
-   <property name="Text" value="When you move your Mane Character to a problem, you may exhaust this card to move this card there." />
+   <property name="Keywords" value="Supportive 1." />
+   <property name="Text" value="When you move your Mane Character to a Problem, you may exhaust this card to move this card there." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -663,7 +682,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="U" />
   </card>
   <card id="de07490c-91bc-4cca-933b-c7f54d3ffadd" name="Shooting Star">
-   <property name="Number" value="cn22" />
+   <property name="Number" value="CN22" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Tale Teller" />
@@ -673,7 +692,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="While an opponent's Mane Character is at home, if you would draw a card during your Ready Phase, you may draw 2 cards and discard a card instead." />
+   <property name="Text" value="At the end of your draw step, if an opponent's Mane Character is at home, you may draw a card and discard a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -682,8 +701,8 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="C" />
   </card>
-  <card id="54e35036-7662-4ebe-95f6-93348b6d51f1" name="Sprinkle Meledy">
-   <property name="Number" value="cn23" />
+  <card id="54e35036-7662-4ebe-95f6-93348b6d51f1" name="Sprinkle Medley">
+   <property name="Number" value="CN23" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Drip Dropper" />
@@ -692,8 +711,8 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Swift" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Swift." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -703,7 +722,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="C" />
   </card>
   <card id="64d22178-5e9e-40d7-9f3a-5656c8888b13" name="Apple Bumpkin">
-   <property name="Number" value="cn24" />
+   <property name="Number" value="CN24" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Caramel Coater" />
@@ -723,7 +742,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="Rarity" value="C" />
   </card>
   <card id="825da05c-215f-41db-b13f-eaed527976ce" name="Applejack">
-   <property name="Number" value="cn25" />
+   <property name="Number" value="CN25" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Element of Honesty" />
@@ -733,8 +752,7 @@ At the end of your turn, if you have a Friend with at least 5 power, turn this c
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony, Unique" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card enters play at a Problem, you may dismiss an opponent's Troublemaker at that Problem.
-If an opponent would force you to discard this card, you may put it into play instead." />
+   <property name="Text" value="When this card enters play at a Problem, you may dismiss an opponent's Troublemaker at that Problem.&#10;If an opponent would force you to discard this card, you may put it into play instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -744,7 +762,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="Rarity" value="R" />
   </card>
   <card id="d4cd6c9c-55f7-4c65-b7e5-73608c841100" name="Applejack">
-   <property name="Number" value="cn26" />
+   <property name="Number" value="CN26" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Applebucker" />
@@ -764,7 +782,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="Rarity" value="U" />
   </card>
   <card id="b9fd648e-f11f-496d-9b8c-0c2d459b2d9a" name="Bags Valet">
-   <property name="Number" value="cn27" />
+   <property name="Number" value="CN27" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Luggage Lackey" />
@@ -784,7 +802,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="Rarity" value="C" />
   </card>
   <card id="9130542f-6e5a-437c-8ddc-a96ebee97f76" name="Big Mac">
-   <property name="Number" value="cn28" />
+   <property name="Number" value="CN28" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Biggest Brother" />
@@ -793,7 +811,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Supportive 2" />
+   <property name="Keywords" value="Supportive 2." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -804,7 +822,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="Rarity" value="R" />
   </card>
   <card id="a22f772c-ee9d-4d3c-863d-1da4b7dfae53" name="Cherry Fizzy">
-   <property name="Number" value="cn29" />
+   <property name="Number" value="CN29" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Stalwart Soldier" />
@@ -824,7 +842,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="Rarity" value="C" />
   </card>
   <card id="e83a09cc-ae17-4b9b-a571-51657cadd106" name="Cloudy Quartz">
-   <property name="Number" value="cn30" />
+   <property name="Number" value="CN30" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Concerned Mother" />
@@ -833,7 +851,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Supportive 2" />
+   <property name="Keywords" value="Supportive 2." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -844,7 +862,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="Rarity" value="C" />
   </card>
   <card id="c3fa1d47-de76-4bf3-b561-1ddb71d57ae3" name="Daisy">
-   <property name="Number" value="cn31" />
+   <property name="Number" value="CN31" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Mousy Mare" />
@@ -864,7 +882,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="Rarity" value="U" />
   </card>
   <card id="60931805-ef91-4b96-bcec-bf32f8675081" name="Doc Top">
-   <property name="Number" value="cn32" />
+   <property name="Number" value="CN32" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Pony Pediatrician" />
@@ -874,8 +892,7 @@ If an opponent would force you to discard this card, you may put it into play in
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card.
-While this card is exhausted, you pay 1 less to rally your Friends (to a minimum of 1)." />
+   <property name="Text" value="Main Phase: Exhaust this card.&#10;While this card is exhausted, you pay 1AT less to rally your Friends (to a minimum of 1AT)." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -885,7 +902,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="Rarity" value="C" />
   </card>
   <card id="67b0ed99-8b89-453e-9999-f8bace501f5e" name="Earth Pony Royal Guard">
-   <property name="Number" value="cn33" />
+   <property name="Number" value="CN33" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Arresting Officer" />
@@ -905,7 +922,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="Rarity" value="R" />
   </card>
   <card id="c2196692-b937-4d55-ac02-8f235217ec73" name="Fast Clip">
-   <property name="Number" value="cn34" />
+   <property name="Number" value="CN34" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Drill Instructor" />
@@ -914,7 +931,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Main Phase: Spend a card from beneath this card to exhaust all characters at this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -925,7 +942,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="Rarity" value="R" />
   </card>
   <card id="468a9121-8ae6-441a-8f2b-eb08d082f6b2" name="Golden Harvest">
-   <property name="Number" value="cn35" />
+   <property name="Number" value="CN35" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Beyond Her Garden" />
@@ -934,8 +951,8 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Stubborn" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Stubborn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -945,17 +962,17 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="Rarity" value="C" />
   </card>
   <card id="e809e7f6-8c14-4738-a986-079555b58684" name="Hayseed Turnip Truck">
-   <property name="Number" value="cn36" />
+   <property name="Number" value="CN36" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
-   <property name="Subname" value="A For Effort" />
+   <property name="Subname" value='"A" For Effort' />
    <property name="Power" value="2" />
    <property name="Cost" value="3" />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Pumped" />
-   <property name="Text" value="During faceoffs involving this card, if this card has at least 1 card beneath it, flip another card." />
+   <property name="Keywords" value="Pumped." />
+   <property name="Text" value="During faceoffs involving this card, if this card has at least 1 card beneath it, flip an additional card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -965,7 +982,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="Rarity" value="U" />
   </card>
   <card id="6d7b4c2c-56fe-4a7d-b2c5-7059bf96898c" name="Joe">
-   <property name="Number" value="cn37" />
+   <property name="Number" value="CN37" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Doughnuteer" />
@@ -975,7 +992,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to reveal a card from your hand and banish it to beneath one of your Friends with Pumped." />
+   <property name="Text" value="Main Phase: Exhaust this card and pay 1AT to reveal a card from your hand and banish it to beneath one of your Friends with Pumped." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -985,7 +1002,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="Rarity" value="R" />
   </card>
   <card id="7fc3a75b-4821-4f32-9fde-71e803cf28a1" name="Steam Roller">
-   <property name="Number" value="cn38" />
+   <property name="Number" value="CN38" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Juggernaut" />
@@ -994,7 +1011,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Pegasus" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="While this card has at least 1 card beneath it, it can't be dismissed or frightened." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1005,7 +1022,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="Rarity" value="C" />
   </card>
   <card id="efbba895-38cf-4770-b0f7-c767a9742d3a" name="Aura">
-   <property name="Number" value="cn39" />
+   <property name="Number" value="CN39" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Really Rambunctious" />
@@ -1014,8 +1031,8 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony, Foal" />
-   <property name="Keywords" value="Random" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Random." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1025,7 +1042,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="Rarity" value="C" />
   </card>
   <card id="a8fae0cf-90be-473f-a64a-857e54fa70a9" name="Cheese Sandwich">
-   <property name="Number" value="cn40" />
+   <property name="Number" value="CN40" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Wandering Partier" />
@@ -1035,8 +1052,7 @@ While this card is exhausted, you pay 1 less to rally your Friends (to a minimum
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="This card enters play exhausted.
-Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Friend." />
+   <property name="Text" value="This card enters play exhausted.&#10;Main Phase: Exhaust this card and put it into your hand to dismiss an exhausted Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1046,7 +1062,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="R" />
   </card>
   <card id="3c733568-aa57-4113-9be3-49f32b09f181" name="Purple Waters">
-   <property name="Number" value="cn41" />
+   <property name="Number" value="CN41" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Prismatic Poet/Musician" />
@@ -1066,7 +1082,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="C" />
   </card>
   <card id="4940065e-fabe-4317-8708-6621e416e3ae" name="Globe Trotter">
-   <property name="Number" value="cn42" />
+   <property name="Number" value="CN42" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Sight Seer" />
@@ -1075,7 +1091,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Main Phase: Spend a card from beneath this card to draw 2 cards." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1086,7 +1102,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="U" />
   </card>
   <card id="a72e225f-a380-4ea9-b5a7-6afbfe2408b1" name="Lily">
-   <property name="Number" value="cn43" />
+   <property name="Number" value="CN43" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Panicked Pony" />
@@ -1106,7 +1122,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="U" />
   </card>
   <card id="47994628-fff4-493a-ba3e-7070e7083b8f" name="Lucky Star">
-   <property name="Number" value="cn44" />
+   <property name="Number" value="CN44" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Charming Cheerer" />
@@ -1126,7 +1142,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="C" />
   </card>
   <card id="72ade957-c22e-48e5-a4f5-2dae48cc91c6" name="Hondo Flanks">
-   <property name="Number" value="cn45" />
+   <property name="Number" value="CN45" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Big Daddy" />
@@ -1135,7 +1151,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Supportive 4" />
+   <property name="Keywords" value="Supportive 4." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1146,7 +1162,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="C" />
   </card>
   <card id="97082419-23f7-4213-b7b1-0c10bc8dac9e" name="Pinkie Pie">
-   <property name="Number" value="cn46" />
+   <property name="Number" value="CN46" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Element of Laughter" />
@@ -1156,7 +1172,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony, Unique" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card enters play, you may reveal the top card of your deck. If you do, reveal cards from the top of your deck until you reveal a number of Friends equal to that card's printed power. Put any number of revealed [Laughter] friends into your hand and shuffle all other revealed cards into your deck. All opponents draw 1 card for each Friend you put into your hand." />
+   <property name="Text" value="When this card enters play, you may reveal the top card of your deck. If you do, reveal cards from the top of your deck until you reveal a number of Friends equal to that card's printed power. Put any number of revealed [Laughter] Friends into your hand and shuffle all other revealed cards into your deck. All opponents draw 1 card for each Friend you put into your hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1166,7 +1182,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="R" />
   </card>
   <card id="ba6a8a20-ac4d-4733-80a9-b3de72a7353e" name="Pinny Lane">
-   <property name="Number" value="cn47" />
+   <property name="Number" value="CN47" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Bowl'em Over" />
@@ -1186,7 +1202,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="R" />
   </card>
   <card id="662cb1f6-8c45-4202-aeb4-a4fb859c16f7" name="Sassaflash">
-   <property name="Number" value="cn48" />
+   <property name="Number" value="CN48" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Striking!" />
@@ -1206,7 +1222,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="Rarity" value="R" />
   </card>
   <card id="8691f671-7ab4-4d43-84d8-da1588f6b435" name="Snails">
-   <property name="Number" value="cn49" />
+   <property name="Number" value="CN49" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Deep Thinker" />
@@ -1216,8 +1232,7 @@ Main Phase: Exhaust this card and put it in your hand to dismiss an exhausted Fr
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn, Foal" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card.
-While this card is exhausted, your opponent needs +2 [Any] to confront this card's Problem." />
+   <property name="Text" value="Main Phase: Exhaust this card.&#10;While this card is exhausted, your opponent needs +2 power to confront this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1227,7 +1242,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="C" />
   </card>
   <card id="d8df2879-2f44-4e62-9dfa-e2872f489a96" name="Snips">
-   <property name="Number" value="cn50" />
+   <property name="Number" value="CN50" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Schemer" />
@@ -1236,7 +1251,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn, Foal" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Main Phase: Exhaust this card and spend 2 cards from beneath it to dismiss an opponent's Friend at this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1246,8 +1261,8 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="R" />
   </card>
-  <card id="1916a06c-3f0b-46db-bdf3-11c1c0967d15" name="Snips and Snails">
-   <property name="Number" value="cn51" />
+  <card id="1916a06c-3f0b-46db-bdf3-11c1c0967d15" name="Snips &amp; Snails">
+   <property name="Number" value="CN51" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Problem Solvers" />
@@ -1257,7 +1272,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn, Foal" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase, Exhaust and retire this card to replace its Problem." />
+   <property name="Text" value="Main Phase: Exhaust and retire this card to replace its Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1267,7 +1282,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="R" />
   </card>
   <card id="63006f9a-fa73-4e4a-9bb1-f3a36b530a98" name="Swan Song">
-   <property name="Number" value="cn52" />
+   <property name="Number" value="CN52" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Fun-loving Debutante" />
@@ -1276,7 +1291,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="This card has +1 power for each card beneath it." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1287,7 +1302,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="C" />
   </card>
   <card id="ded69148-0843-4ad2-9047-1b51a73947c8" name="Amethyst Maresbury">
-   <property name="Number" value="cn53" />
+   <property name="Number" value="CN53" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Crystal Librarian" />
@@ -1296,8 +1311,8 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony, Crystal, Elder" />
-   <property name="Keywords" value="Pumped" />
-   <property name="Text" value="When you win a faceoff involving this card, you may spend any number of cards from beneath this card to gain 1 for each card you spent." />
+   <property name="Keywords" value="Pumped." />
+   <property name="Text" value="When you win a faceoff involving this card, you may spend any number of cards from beneath this card to gain 1AT for each card you spent." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1307,7 +1322,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="U" />
   </card>
   <card id="8256b30b-c66c-48d9-b214-f1e9ce62c168" name="Canterlot Archive Guard">
-   <property name="Number" value="cn54" />
+   <property name="Number" value="CN54" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Literate Lookout" />
@@ -1327,7 +1342,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="R" />
   </card>
   <card id="e649c4ff-baae-413c-8964-ad635d769453" name="Compass Star">
-   <property name="Number" value="cn55" />
+   <property name="Number" value="CN55" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Geography Nut" />
@@ -1347,7 +1362,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="C" />
   </card>
   <card id="fa9dcb4e-f909-4d83-8102-bc3de7427b66" name="Four Step">
-   <property name="Number" value="cn56" />
+   <property name="Number" value="CN56" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Dance Teacher" />
@@ -1367,7 +1382,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="C" />
   </card>
   <card id="1dd73e76-4133-499c-aa8a-ea8d8d0fd911" name="Minuette">
-   <property name="Number" value="cn57" />
+   <property name="Number" value="CN57" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Clocked Up" />
@@ -1387,7 +1402,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="R" />
   </card>
   <card id="bb8ff645-ac59-432f-9a78-88a663ce0151" name="Perfect Pace">
-   <property name="Number" value="cn58" />
+   <property name="Number" value="CN58" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Time Master" />
@@ -1396,7 +1411,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Faceoff: Spend a card from beneath this card to give this card +4 power until the end of the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1407,7 +1422,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="C" />
   </card>
   <card id="b7006cf9-e03a-44a8-a02d-f4ea42345ffb" name="Princess Luna">
-   <property name="Number" value="cn59" />
+   <property name="Number" value="CN59" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Night Mare" />
@@ -1417,7 +1432,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Alicorn, Royalty" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card to a Problem, frighten a Friend at that Problem." />
+   <property name="Text" value="When this card enters play at a Problem, frighten a Friend there." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1427,17 +1442,17 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="U" />
   </card>
   <card id="13bb1eb7-a881-49a2-9afa-1a452095c2e1" name="Sealed Scroll">
-   <property name="Number" value="cn60" />
+   <property name="Number" value="CN60" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Studious Scribe" />
-   <property name="Power" value="" />
+   <property name="Power" value="1" />
    <property name="Cost" value="1" />
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Studious" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Studious." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1447,7 +1462,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="C" />
   </card>
   <card id="5947394a-2a2c-4b01-841c-5f3aed0099cc" name="Shining Armor">
-   <property name="Number" value="cn61" />
+   <property name="Number" value="CN61" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Captain of the Guard" />
@@ -1467,7 +1482,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="R" />
   </card>
   <card id="d6e3c204-5035-42f9-85e6-b2b89b44e191" name="Spike">
-   <property name="Number" value="cn62" />
+   <property name="Number" value="CN62" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Assistant Librarian" />
@@ -1477,7 +1492,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Dragon" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase; Exhaust this card to look at the bottom 2 cards of your deck. You may put 1 of them on top of your deck." />
+   <property name="Text" value="Main Phase: Exhaust this card to look at the bottom 2 cards of your deck. You may put 1 of them on top of your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1487,7 +1502,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="R" />
   </card>
   <card id="5c8558e9-9744-41a8-a662-a3ffb603d743" name="Starry Eyes">
-   <property name="Number" value="cn63" />
+   <property name="Number" value="CN63" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Space Cadet" />
@@ -1507,7 +1522,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="C" />
   </card>
   <card id="775347e1-86bc-45ab-b0bf-8b8ae960f66f" name="Tall Order">
-   <property name="Number" value="cn64" />
+   <property name="Number" value="CN64" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Council Colt" />
@@ -1516,7 +1531,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Reaction: After an opponent plays or moves a Friend to this card's Problem, you may spend a card from beneath this card to move that Friend home." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1527,7 +1542,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="Rarity" value="F" />
   </card>
   <card id="59a1ab57-69fa-4a04-b895-6d830ef54eb7" name="Twilight Sparkle">
-   <property name="Number" value="cn65" />
+   <property name="Number" value="CN65" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Element of Magic" />
@@ -1537,8 +1552,7 @@ While this card is exhausted, your opponent needs +2 [Any] to confront this card
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn, Unique" />
    <property name="Keywords" value="" />
-   <property name="Text" value="You pay 1 less to play Events.
-When you play an Event, look at the top card of your deck.  You may put that card on the bottom of your deck." />
+   <property name="Text" value="You pay 1AT less to play Events.&#10;When you play an Event, look at the top card of your deck. You may put that card on the bottom of your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1548,7 +1562,7 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="Rarity" value="R" />
   </card>
   <card id="26477159-b180-4147-934b-a04d9d7c82ff" name="Twilight Velvet">
-   <property name="Number" value="cn66" />
+   <property name="Number" value="CN66" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Proud Mom" />
@@ -1557,7 +1571,7 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Supportive 2" />
+   <property name="Keywords" value="Supportive 2." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1568,16 +1582,16 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="Rarity" value="C" />
   </card>
   <card id="26bd889b-11d0-45a8-8eef-4deb6777628a" name="Zecora">
-   <property name="Number" value="cn67" />
+   <property name="Number" value="CN67" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
-   <property name="Subname" value="Mangical Mentor" />
+   <property name="Subname" value="Magical Mentor" />
    <property name="Power" value="1" />
    <property name="Cost" value="1" />
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Zebra" />
-   <property name="Keywords" value="Supportive 1" />
+   <property name="Keywords" value="Supportive 1." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1588,7 +1602,7 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="Rarity" value="C" />
   </card>
   <card id="52e22071-9071-4570-9e54-ffc427188524" name="Cookie Crumbles">
-   <property name="Number" value="cn68" />
+   <property name="Number" value="CN68" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Fancy Cooker" />
@@ -1597,8 +1611,8 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Supportive 2" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="Supportive 2." />
+   <property name="Text" value="Opponents can't move this card or your Mane Character." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1608,16 +1622,16 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="Rarity" value="C" />
   </card>
   <card id="0e700a95-5294-4eb2-83c8-324283f69cb0" name="Coco Pommel">
-   <property name="Number" value="cn69" />
+   <property name="Number" value="CN69" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
-   <property name="Subname" value="Fashion Assistant" />
+   <property name="Subname" value="Fashion Apprentice" />
    <property name="Power" value="3" />
    <property name="Cost" value="4" />
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Main Phase: Spend a card from beneath this card to give another character +4 power until the end of the turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1628,7 +1642,7 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="Rarity" value="C" />
   </card>
   <card id="7bab41fb-0aa8-4146-be65-e97b4abb1c54" name="Fleur Dis Lee">
-   <property name="Number" value="cn70" />
+   <property name="Number" value="CN70" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Trendy Follower" />
@@ -1637,7 +1651,7 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Supportive 1" />
+   <property name="Keywords" value="Supportive 1." />
    <property name="Text" value="While involved in a faceoff, this card also has Supportive 2." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1648,7 +1662,7 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="Rarity" value="C" />
   </card>
   <card id="6e6e7198-6679-48f6-8db1-7a797737e80b" name="Foggy Fleece">
-   <property name="Number" value="cn71" />
+   <property name="Number" value="CN71" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Cloud Crafter" />
@@ -1668,7 +1682,7 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="Rarity" value="C" />
   </card>
   <card id="a60514bc-9d4a-44a2-bc6f-e5659e98cef5" name="Golden Gavel">
-   <property name="Number" value="cn72" />
+   <property name="Number" value="CN72" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Fast Talker" />
@@ -1678,8 +1692,7 @@ When you play an Event, look at the top card of your deck.  You may put that car
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Pay 1 to exhaust this card.
-While this card is exhausted, your opponent must pay 1 to play or move a card this card's Problem." />
+   <property name="Text" value="Main Phase: Pay 1AT to exhaust this card.&#10;While this card is exhausted, your opponent must pay +1AT to play or move a character to this card's Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1689,7 +1702,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="F" />
   </card>
   <card id="58cbd845-b273-4e51-aed9-4555cd647827" name="Hoity Toity">
-   <property name="Number" value="cn73" />
+   <property name="Number" value="CN73" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Fashion Critic" />
@@ -1709,7 +1722,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="R" />
   </card>
   <card id="39419263-d2c6-4a03-a52b-b118717a214e" name="Octavia">
-   <property name="Number" value="cn74" />
+   <property name="Number" value="CN74" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Star Cellist" />
@@ -1729,7 +1742,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="U" />
   </card>
   <card id="088edad1-eb92-4b51-8428-5a8b36f9441d" name="Photo Finish">
-   <property name="Number" value="cn75" />
+   <property name="Number" value="CN75" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Picture Perfect Pony" />
@@ -1738,7 +1751,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="When you win a faceoff involving this card, you may spend a card from beneath it to banish an opponent's Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1749,7 +1762,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="U" />
   </card>
   <card id="8071a41f-b5b5-4912-afdf-8f7ec867447e" name="Prim Posy">
-   <property name="Number" value="cn76" />
+   <property name="Number" value="CN76" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Fond of Fronds" />
@@ -1769,7 +1782,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="C" />
   </card>
   <card id="bedf863a-fc51-4e6d-bb1a-a36e91021197" name="Rarity">
-   <property name="Number" value="cn77" />
+   <property name="Number" value="CN77" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Dragon Charmer" />
@@ -1789,7 +1802,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="U" />
   </card>
   <card id="498b2033-cbdd-4a2a-86a2-d14eecf8709a" name="Rarity">
-   <property name="Number" value="cn78" />
+   <property name="Number" value="CN78" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Element of Generosity" />
@@ -1809,7 +1822,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="R" />
   </card>
   <card id="50a66414-d445-44a2-ba0c-a2012818b18f" name="Roseluck">
-   <property name="Number" value="cn79" />
+   <property name="Number" value="CN79" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Fainthearted Filly" />
@@ -1819,7 +1832,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: When one of your Friends is retired, you may exhaust this card. If you do, put a different Friend from your discard pile into your hand." />
+   <property name="Text" value="Reaction: After one of your Friends is retired, you may exhaust this card. If you do, put another Friend from your discard pile into your hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1829,7 +1842,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="U" />
   </card>
   <card id="2a88dd51-17e7-41a2-8609-c37d8c13d985" name="Sapphire Shores">
-   <property name="Number" value="cn80" />
+   <property name="Number" value="CN80" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Costume Changer" />
@@ -1849,7 +1862,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="C" />
   </card>
   <card id="18c07e2d-07d0-45b8-a58c-745e5cae2a68" name="Silver Frames">
-   <property name="Number" value="cn81" />
+   <property name="Number" value="CN81" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Art Curator" />
@@ -1858,8 +1871,8 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Inspired." />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Inspired." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1869,7 +1882,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="C" />
   </card>
   <card id="ba0129c8-14a2-44a8-8c3a-252d71b8f330" name="Twilight Sky">
-   <property name="Number" value="cn82" />
+   <property name="Number" value="CN82" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Stanchion Stallion" />
@@ -1879,7 +1892,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Earth Pony" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When an opponent moves a Friend to this card's Problem, that opponent may pay 1. If they don't, exhaust that Friend." />
+   <property name="Text" value="When an opponent moves a Friend to this card's Problem, that opponent may pay 1AT. If they don't, exhaust that Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1889,7 +1902,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="R" />
   </card>
   <card id="aed54d4d-cdd3-487d-811c-4643e45b64e5" name="Angel">
-   <property name="Number" value="cn83" />
+   <property name="Number" value="CN83" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Serious Business" />
@@ -1898,7 +1911,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Critter" />
-   <property name="Keywords" value="Supportive 2" />
+   <property name="Keywords" value="Supportive 2." />
    <property name="Text" value="" />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1909,7 +1922,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="R" />
   </card>
   <card id="e2887b78-61b2-427e-aa02-a591828ec401" name="Blossomforth">
-   <property name="Number" value="cn84" />
+   <property name="Number" value="CN84" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Too Flexible" />
@@ -1919,7 +1932,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="During a faceoff involving this card, if you would put a flipped Friend card on the bottom of your deck, you may retire this card and pay 2 to put that Friend into play at this card's Problem instead." />
+   <property name="Text" value="During a faceoff involving this card, if you would put a flipped Friend card on the bottom of your deck, you may retire this card and pay 2AT to put that Friend into play at this card's Problem instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1929,7 +1942,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="R" />
   </card>
   <card id="331335be-4611-44cb-9e1d-79af84f2c940" name="Doctor Horse">
-   <property name="Number" value="cn85" />
+   <property name="Number" value="CN85" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="M.D." />
@@ -1938,7 +1951,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="Each of your other Friends at this card's Problem have +1 power for each card beneath this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -1949,7 +1962,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="F" />
   </card>
   <card id="65f83e87-1c73-4005-81b9-e05877000461" name="Eagle">
-   <property name="Number" value="cn86" />
+   <property name="Number" value="CN86" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Soaring Raptor" />
@@ -1958,8 +1971,8 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Critter" />
-   <property name="Keywords" value="Pumped" />
-   <property name="Text" value="Reaction: At the start of any phase, you may spend a card from beneath this card to move this card." />
+   <property name="Keywords" value="Pumped." />
+   <property name="Text" value="Reaction: After the start of any phase, you may spend a card from beneath this card to move this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -1969,7 +1982,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="U" />
   </card>
   <card id="7fdc907c-490f-4d0d-93ad-5422580ee469" name="Fine Line">
-   <property name="Number" value="cn87" />
+   <property name="Number" value="CN87" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Au Pair" />
@@ -1989,7 +2002,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="C" />
   </card>
   <card id="24ebbb2b-4606-42c5-a449-0b01bb1ac911" name="Fluttershy">
-   <property name="Number" value="cn88" />
+   <property name="Number" value="CN88" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Critter Caregiver" />
@@ -1999,7 +2012,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Pegasus" />
    <property name="Keywords" value="" />
-   <property name="Text" value="[Critter] Friends don't count towards your home limit." />
+   <property name="Text" value="Critter Friends don't count towards your home limit." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2009,7 +2022,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="Rarity" value="U" />
   </card>
   <card id="a220527e-3f0f-480e-a59f-6506fa3bfaf8" name="Fluttershy">
-   <property name="Number" value="cn89" />
+   <property name="Number" value="CN89" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Element of Kindness" />
@@ -2019,8 +2032,7 @@ While this card is exhausted, your opponent must pay 1 to play or move a card th
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Pegasus, Unique" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this card enters play you may search your deck for up to 2 [Critter] Friends and put them into your hand.
-Faceoff: Discard a [Critter] Friend to give a Friend +2 power until the end of the faceoff." />
+   <property name="Text" value="When this card enters play you may search your deck for up to 2 Critter Friends and put them into your hand.&#10;Faceoff: Discard a Critter Friend to give a Friend +2 power until the end of the faceoff." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2030,7 +2042,7 @@ Faceoff: Discard a [Critter] Friend to give a Friend +2 power until the end of t
    <property name="Rarity" value="R" />
   </card>
   <card id="00c5d0bb-dc1a-4c25-aaa5-38cc12a96a28" name="Goldie Delicious">
-   <property name="Number" value="cn90" />
+   <property name="Number" value="CN90" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Cat Hoarder" />
@@ -2040,8 +2052,7 @@ Faceoff: Discard a [Critter] Friend to give a Friend +2 power until the end of t
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Earth Pony, Elder" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Exhaust this card.
-While this card is exhausted, your [Critter] Friends at this its Problem each have +1 power." />
+   <property name="Text" value="Main Phase: Exhaust this card.&#10;While this card is exhausted, your Critter Friends at its Problem each have +1 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2051,7 +2062,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="0a84b152-6e73-4b89-8ab2-c7926f751c6e" name="Lemon Hearts">
-   <property name="Number" value="cn91" />
+   <property name="Number" value="CN91" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Sweetheart" />
@@ -2060,8 +2071,8 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Caretaker" />
-   <property name="Text" value="" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Caretaker." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2071,7 +2082,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="C" />
   </card>
   <card id="77ccf6be-b2c4-4bc4-9386-e22ca0e00757" name="Liza Doolots">
-   <property name="Number" value="cn92" />
+   <property name="Number" value="CN92" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Boundless Energy" />
@@ -2091,7 +2102,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="C" />
   </card>
   <card id="9ab3fff9-845e-43af-90d0-8af023375f38" name="Manny Roar">
-   <property name="Number" value="cn93" />
+   <property name="Number" value="CN93" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Mild Manticore" />
@@ -2111,7 +2122,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="C" />
   </card>
   <card id="601c6c7e-c53f-43e6-8f62-a73c1df1f236" name="Mrs. Cake">
-   <property name="Number" value="cn94" />
+   <property name="Number" value="CN94" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Dessertier" />
@@ -2120,7 +2131,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Supportive 1" />
+   <property name="Keywords" value="Supportive 1." />
    <property name="Text" value="Your Mane Character has +1 power while at a Problem with this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -2131,17 +2142,17 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="C" />
   </card>
   <card id="92070159-c7b2-4f44-b6ed-1dd4026978be" name="Nurse Redheart">
-   <property name="Number" value="cn95" />
+   <property name="Number" value="CN95" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
-   <property name="Subname" value="Cantakerous Caretaker" />
+   <property name="Subname" value="Cantankerous Caretaker" />
    <property name="Power" value="3" />
    <property name="Cost" value="3" />
    <property name="PlayRequiredPower" value="4" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Pumped" />
-   <property name="Text" value="Reaction: At the start of a Score Phase, you may spend a card from beneath this card to put an opponent's Friend into its owner's hand." />
+   <property name="Keywords" value="Pumped." />
+   <property name="Text" value="Reaction: After the start of a Score Phase, you may spend a card from beneath this card to put an opponent's Friend into its owner's hand." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2151,7 +2162,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="7d71e706-dda2-4249-9a97-bac0e97e131f" name="Princess Celestia">
-   <property name="Number" value="cn96" />
+   <property name="Number" value="CN96" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Bringer of Light" />
@@ -2171,7 +2182,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="ef2e3588-b53f-40ec-9073-c0fe59de149d" name="Raccoon">
-   <property name="Number" value="cn97" />
+   <property name="Number" value="CN97" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Scrounger" />
@@ -2191,7 +2202,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="C" />
   </card>
   <card id="a34a03d9-4055-4cfc-9dcd-f9d4c74de06b" name="Whitewash">
-   <property name="Number" value="cn98" />
+   <property name="Number" value="CN98" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Amiable Aviator" />
@@ -2211,7 +2222,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="C" />
   </card>
   <card id="3694eced-d014-4f03-afcb-e742fb095be3" name="A Major Problem">
-   <property name="Number" value="cn99" />
+   <property name="Number" value="CN99" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2231,7 +2242,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="b5b5c59f-ca7e-4f4a-83be-61b409f036d2" name="Anything I Can Do To Help?">
-   <property name="Number" value="cn100" />
+   <property name="Number" value="CN100" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2251,7 +2262,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="c61f8256-e61d-4ba5-8842-b030ff5375b6" name="Biff! Pow!">
-   <property name="Number" value="cn101" />
+   <property name="Number" value="CN101" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2259,7 +2270,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Cost" value="0" />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
-   <property name="Traits" value="" />
+   <property name="Traits" value="Showdown" />
    <property name="Keywords" value="" />
    <property name="Text" value="Main Phase: Challenge an opponent's Troublemaker with one of your characters." />
    <property name="ProblemBonus" value="" />
@@ -2271,7 +2282,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="c4d41c36-04f4-4d05-ae94-2ddaa4a9e519" name="Critter Stampede">
-   <property name="Number" value="cn102" />
+   <property name="Number" value="CN102" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2291,7 +2302,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="00a80d18-ba1d-44e5-80f3-4f3c25679e81" name="Eep!">
-   <property name="Number" value="cn103" />
+   <property name="Number" value="CN103" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2311,7 +2322,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="2e6ba268-05fa-4344-aac0-6a036bc25a0d" name="Fashion Week">
-   <property name="Number" value="cn104" />
+   <property name="Number" value="CN104" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2331,7 +2342,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="57bc7706-1701-43f7-a216-f3373a901211" name="Furry Free-for-All">
-   <property name="Number" value="cn105" />
+   <property name="Number" value="CN105" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2341,7 +2352,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Gotcha" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: At the start of a faceoff, all players shuffle their decks." />
+   <property name="Text" value="Reaction: After the start of a faceoff, all players shuffle their decks." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2351,7 +2362,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="4ec5c34f-0b8f-41b4-a4b3-3e3e09149a99" name="Hoofwrasslin'">
-   <property name="Number" value="cn106" />
+   <property name="Number" value="CN106" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2371,7 +2382,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="80a98f0e-cc2a-4049-8cb3-07c602715151" name="I Got a Golden Ticket!">
-   <property name="Number" value="cn107" />
+   <property name="Number" value="CN107" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2381,7 +2392,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Problem Faceoff: Choose a  Friend in your discard pile. Put it into play at a Problem where a faceoff is being resolved. At the end of the faceoff, banish that Friend." />
+   <property name="Text" value="Problem Faceoff: Choose a Friend in your discard pile. Put it into play at a Problem where a faceoff is being resolved. At the end of the faceoff, banish that Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2391,7 +2402,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="f2d3329f-dbf4-472f-b21b-2f1af4203f9e" name="In Your Dreams">
-   <property name="Number" value="cn108" />
+   <property name="Number" value="CN108" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2401,7 +2412,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Choose odd or even and then reveal the top card of your deck. If that card's printed power matches your choice, gain 1 and draw a card. Otherwise, draw a card. (0 counts as even.)" />
+   <property name="Text" value="Main Phase: Choose odd or even and then reveal the top card of your deck. If that card's printed power matches your choice, gain 1AT and draw a card. Otherwise, draw a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2411,7 +2422,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="d79511d1-556b-4c87-8bf1-54b4805b7e42" name="Magic Duel">
-   <property name="Number" value="cn109" />
+   <property name="Number" value="CN109" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2421,7 +2432,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Showdown" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Start a faceoff involving one of your Friends and an opponent's Friend with equal or greater power. The winner of the faceoff gains 1." />
+   <property name="Text" value="Main Phase: Start a faceoff involving one of your Friends and an opponent's Friend with equal or greater power. The winner of the faceoff gains 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2431,7 +2442,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="0d92fe29-c4f4-421a-9916-d52b777f470a" name="Mane-Raising Experience">
-   <property name="Number" value="cn110" />
+   <property name="Number" value="CN110" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2451,7 +2462,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="6b034fad-5805-42dd-b81f-810c0ff80b36" name="Nice Moves, Kid">
-   <property name="Number" value="cn111" />
+   <property name="Number" value="CN111" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2471,7 +2482,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="040c88a8-0f02-4bfc-b4bf-e953a7df5cf6" name="Not On the List">
-   <property name="Number" value="cn112" />
+   <property name="Number" value="CN112" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2491,7 +2502,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="91b2b132-37b5-4a89-82e7-d55efe41fcda" name="Nothing to Be Afraid Of">
-   <property name="Number" value="cn113" />
+   <property name="Number" value="CN113" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2511,7 +2522,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="405d8cdd-91dd-4831-95e7-2724026d5bdc" name="Plum Tuckered Out">
-   <property name="Number" value="cn114" />
+   <property name="Number" value="CN114" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2531,7 +2542,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="069d582d-58d3-4284-9f97-8103f34aa7df" name="Rock, Paper, Scissors, Shoot!">
-   <property name="Number" value="cn115" />
+   <property name="Number" value="CN115" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2541,7 +2552,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Showdown" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Start a faceoff invovling one of your Friends and an opponent's Friend with equal or greater power. At the end of the faceoff, the loser dismisses one of their Friends that was involved." />
+   <property name="Text" value="Main Phase: Start a faceoff involving one of your Friends and an opponent's Friend with equal or greater power. At the end of the faceoff, the loser dismisses one of their Friends that was involved." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2551,7 +2562,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="6b24a067-f1c6-4b86-8943-da8ad3b3f38a" name="ROYAL CANTERLOT VOICE">
-   <property name="Number" value="cn116" />
+   <property name="Number" value="CN116" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2561,7 +2572,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Choose a Problem. Your opponent moves one of their friends away from that Problem. If you control Princess Luna, gain 1." />
+   <property name="Text" value="Main Phase: Choose a Problem. Your opponent moves one of their Friends away from that Problem. If you control Princess Luna, gain 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2571,7 +2582,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="4fd9a829-3d27-4bac-8e83-d8e7bb65be7f" name="Staring Contest">
-   <property name="Number" value="cn117" />
+   <property name="Number" value="CN117" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2588,10 +2599,10 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="ProblemPlayerElement1Power" value="" />
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="u" />
+   <property name="Rarity" value="U" />
   </card>
   <card id="653c1a8a-9a76-4f8a-9d55-ac6da20371b6" name="The Best of Friends">
-   <property name="Number" value="cn118" />
+   <property name="Number" value="CN118" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2601,7 +2612,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Choose a [Kindness] or [Generosity] character.  That character gets +1 [Kindness] and +1 [Generosity] until the end of the phase." />
+   <property name="Text" value="Main Phase: Choose a [Kindness] or [Generosity] character. That character gets +1 [Kindness] and +1 [Generosity] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2611,7 +2622,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="F" />
   </card>
   <card id="84c57b9d-941b-473c-8aed-ae315a711cd9" name="The Brave and the Bold">
-   <property name="Number" value="cn119" />
+   <property name="Number" value="CN119" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2621,7 +2632,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Faceoff: If you have Rainbow Dash or Applejack involved in this faceoff, flip an additional card.  If you have Rainbow Dash and Applejack involved in this faceoff, flip 2 additional cards instead." />
+   <property name="Text" value="Faceoff: If you have Rainbow Dash or Applejack involved in this faceoff, flip an additional card. If you have Rainbow Dash and Applejack involved in this faceoff, flip 2 additional cards instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2631,7 +2642,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="9b9ab8c1-9583-4c31-9771-78b2f4fd276b" name="The Hard Way">
-   <property name="Number" value="cn120" />
+   <property name="Number" value="CN120" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2651,7 +2662,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="70a65f8c-132a-4ab3-a42d-dcdfbfabface" name="The Magic of Adventure">
-   <property name="Number" value="cn121" />
+   <property name="Number" value="CN121" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2661,7 +2672,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Choose a [Loyalty] or [Magic] character. That character gets +1 [Loyalty] and +1 [Magic] until the end of the phase." />
+   <property name="Text" value="Main Phase: Choose a [Loyalty] or [Magic] character. That character gets +1 [Loyalty] and +1 [Magic] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2671,7 +2682,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="F" />
   </card>
   <card id="386d0316-49d2-4ab3-83a8-5eefab1eb303" name="The Sun and the Moon">
-   <property name="Number" value="cn122" />
+   <property name="Number" value="CN122" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2691,7 +2702,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="dc633584-e4d0-4847-afb1-b2d6b60ebadd" name="Thunderclap">
-   <property name="Number" value="cn123" />
+   <property name="Number" value="CN123" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2701,7 +2712,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Frighten a Friend with 2 power or less." />
+   <property name="Text" value="Main Phase: Frighten a Friend with 2 or less power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2711,7 +2722,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="ceb4d9a2-ac12-4bf4-a3e0-713120f726c8" name="Too Much Fun">
-   <property name="Number" value="cn124" />
+   <property name="Number" value="CN124" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2731,7 +2742,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="726da640-bdf6-47cb-8427-93aceb557cbd" name="Very Startling">
-   <property name="Number" value="cn125" />
+   <property name="Number" value="CN125" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2751,7 +2762,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="7141dfc4-ab48-4ecb-8101-d00ee46738e8" name="Wardrobe Malfunction">
-   <property name="Number" value="cn126" />
+   <property name="Number" value="CN126" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2771,7 +2782,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="e463f0a4-df08-4b29-ade1-c396c3077beb" name="What's Old is New Again">
-   <property name="Number" value="cn127" />
+   <property name="Number" value="CN127" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2781,7 +2792,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Until the end of the phase, you may play Friends and Resources from your discard pile. If a Friend or Resource would enter your discard pile this turn, banish it instead." />
+   <property name="Text" value="Main Phase: Until the end of the phase, you may play Friends and Resources from your discard pile. If a Friend or Resource would enter your discard pile this phase, banish it instead. Banish this card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2791,7 +2802,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="93421ead-9a88-4da2-a496-19f32122e3db" name="You've Been Up All Night">
-   <property name="Number" value="cn128" />
+   <property name="Number" value="CN128" />
    <property name="Type" value="Event" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2811,7 +2822,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="02a37b4f-5dbd-4721-841a-2b2dc20dc241" name="A Fiery Temper">
-   <property name="Number" value="cn129" />
+   <property name="Number" value="CN129" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2820,8 +2831,8 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Troublemaker." />
-   <property name="Text" value="That Troublemaker has +2 power." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Troublemaker.&#10;That Troublemaker has +2 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2831,7 +2842,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="C" />
   </card>
   <card id="280a12a7-abd8-4c24-9b0c-dd3ab6eccc80" name="Apple Cider">
-   <property name="Number" value="cn130" />
+   <property name="Number" value="CN130" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2840,8 +2851,8 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="While that Friend is at a Problem, that Problem has 0 bonus points." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;While that Friend is at a Problem, that Problem has 0 bonus points." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2851,7 +2862,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="U" />
   </card>
   <card id="e8acef88-e6ff-48c5-9311-c47c963ace99" name="Bed Rest">
-   <property name="Number" value="cn131" />
+   <property name="Number" value="CN131" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2860,8 +2871,8 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on an opponent's ready Friend." />
-   <property name="Text" value="That Friend can't be exhausted." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on an opponent's ready Friend.&#10;That Friend can't be exhausted." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2871,7 +2882,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="C" />
   </card>
   <card id="a428fbca-fee1-411e-ab18-630c80362431" name="Bell Tower">
-   <property name="Number" value="cn132" />
+   <property name="Number" value="CN132" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2880,8 +2891,8 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card to uncover one of your Troublemakers." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card to uncover one of your Troublemakers." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2891,7 +2902,7 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="Rarity" value="R" />
   </card>
   <card id="ebc4daf7-2acf-4bf0-aeb0-c91ef9ece2de" name="Canterlot Archives">
-   <property name="Number" value="cn133" />
+   <property name="Number" value="CN133" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2900,9 +2911,8 @@ While this card is exhausted, your [Critter] Friends at this its Problem each ha
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card to banish an Event from your hand to beneath this card.
-Reaction: After the start of a faceoff, you may exhaust this card to put a banished card from beneath this card on the top of your deck and gain 1." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card to banish an Event from your hand to beneath this card.&#10;Reaction: After the start of a faceoff, you may exhaust this card to put a banished card from beneath this card on the top of your deck and gain 1AT." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2912,7 +2922,7 @@ Reaction: After the start of a faceoff, you may exhaust this card to put a banis
    <property name="Rarity" value="U" />
   </card>
   <card id="fcd76578-365f-4cad-9c8b-1a0a1927332b" name="Canterlot Hedge Maze">
-   <property name="Number" value="cn134" />
+   <property name="Number" value="CN134" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2921,9 +2931,8 @@ Reaction: After the start of a faceoff, you may exhaust this card to put a banis
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Location, Unique" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to banish an opponent's Friend beneath this card.
-Main Phase: Pay 2 to dismiss this card and put any cards beneath hit into play at their owners' homes. Any player may activate this ability." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and pay 1AT to banish an opponent's Friend to beneath this card.&#10;Main Phase: Pay 2AT to dismiss this card and put any cards beneath it into play at their owners' homes. Any player may activate this ability." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2933,7 +2942,7 @@ Main Phase: Pay 2 to dismiss this card and put any cards beneath hit into play a
    <property name="Rarity" value="R" />
   </card>
   <card id="0c093e7e-442a-454a-887e-dbdae5abdb50" name="Chic Beret">
-   <property name="Number" value="cn135" />
+   <property name="Number" value="CN135" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2942,9 +2951,8 @@ Main Phase: Pay 2 to dismiss this card and put any cards beneath hit into play a
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="That Friend has +1 power and is also [Generosity].
-Main Phase: Pay 1 to reattach this card to another Friend." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;That Friend has +1 power and is also White.&#10;Main Phase: Pay 1AT to reattach this card to another Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2954,7 +2962,7 @@ Main Phase: Pay 1 to reattach this card to another Friend." />
    <property name="Rarity" value="C" />
   </card>
   <card id="eb3c89d4-6886-463e-a58b-be469fec8e9b" name="Chicken Costume">
-   <property name="Number" value="cn136" />
+   <property name="Number" value="CN136" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2963,8 +2971,8 @@ Main Phase: Pay 1 to reattach this card to another Friend." />
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="When that Friend becomes exhausted, dismiss it." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;When that Friend becomes exhausted, dismiss it." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2974,7 +2982,7 @@ Main Phase: Pay 1 to reattach this card to another Friend." />
    <property name="Rarity" value="C" />
   </card>
   <card id="0e777f91-d04f-4aa1-b750-0dcb6248f209" name="Combat Hat">
-   <property name="Number" value="cn137" />
+   <property name="Number" value="CN137" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -2983,9 +2991,8 @@ Main Phase: Pay 1 to reattach this card to another Friend." />
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on one of your Friends." />
-   <property name="Text" value="Your opponent must pay +1 to move a character to that Friend's Problem.
-Main Phase: Pay 1 to reattach this card to another one of your Friends." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on one of your Friends.&#10;Your opponent must pay +1AT to move a character to that Friend's Problem.&#10;Main Phase: Pay 1AT to reattach this card to another one of your Friends." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -2995,7 +3002,7 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="Rarity" value="U" />
   </card>
   <card id="e8e54ead-f2d3-4645-be21-f34d60c68a3f" name="Funny Glasses">
-   <property name="Number" value="cn138" />
+   <property name="Number" value="CN138" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3004,8 +3011,8 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Accessory" />
-   <property name="Keywords" value="Play on one of your Friends." />
-   <property name="Text" value="Main Phase: Exhaust that Friend to give your Friends [Laughter] until the end of the phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on one of your Friends.&#10;Main Phase: Exhaust that Friend to give your Friends [Laughter] until the end of the phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3014,18 +3021,18 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="U" />
   </card>
-  <card id="ba729fc3-b7d7-47e0-982e-3a3694c30384" name="Go, Feed!">
-   <property name="Number" value="cn139" />
+  <card id="ba729fc3-b7d7-47e0-982e-3a3694c30384" name="Go">
+   <property name="Number" value="CN139" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
-   <property name="Subname" value="" />
+   <property name="Subname" value="Feed!" />
    <property name="Power" value="4" />
    <property name="Cost" value="1" />
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on a Troublemaker." />
-   <property name="Text" value="If a player loses a faceoff involving that Troublemaker and would send a Friend home, dismiss that Friend instead." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Troublemaker.&#10;If a player loses a faceoff involving that Troublemaker and would send a Friend home, they dismiss that Friend instead." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3035,7 +3042,7 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="Rarity" value="R" />
   </card>
   <card id="ee821144-dfae-4848-a584-4eb487637e8a" name="I Just Can't Decide!">
-   <property name="Number" value="cn140" />
+   <property name="Number" value="CN140" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3044,8 +3051,8 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Report" />
-   <property name="Keywords" value="Play on a Problem." />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to move an opponent's character away from that Problem." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Problem.&#10;Main Phase: Exhaust this card and pay 1AT to move an opponent's character away from that Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3055,7 +3062,7 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="Rarity" value="R" />
   </card>
   <card id="5a2a0f35-ba7d-4432-b768-56cd49f0bdb1" name="Joe's Doughnut Shop">
-   <property name="Number" value="cn141" />
+   <property name="Number" value="CN141" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3064,8 +3071,8 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Spend a card from beneath one of your Friends with Pumped to give that Friend +2 power until the end of the turn." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Spend a card from beneath one of your Friends with Pumped to give that Friend +2 power until the end of the turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3075,7 +3082,7 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="Rarity" value="U" />
   </card>
   <card id="16581083-1d61-4d93-b593-281229813b90" name="Learned Lessons">
-   <property name="Number" value="cn142" />
+   <property name="Number" value="CN142" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3084,9 +3091,8 @@ Main Phase: Pay 1 to reattach this card to another one of your Friends." />
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="When you score a  Problem's bonus points, banish the top card of your deck beneath this card.
-Main Phase: Spend all the cards beneath this card and retire it to gain a number of action tokens equal to the number of cards spent." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;When you score a Problem's bonus points, banish the top card of your deck to beneath this card.&#10;Main Phase: Spend all the cards beneath this card and retire it to gain a number of action tokens equal to the number of cards spent." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3096,7 +3102,7 @@ Main Phase: Spend all the cards beneath this card and retire it to gain a number
    <property name="Rarity" value="R" />
   </card>
   <card id="998d45ca-2598-4ab4-834c-4c578f67d50d" name="Monstrous Cave">
-   <property name="Number" value="cn143" />
+   <property name="Number" value="CN143" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3105,8 +3111,8 @@ Main Phase: Spend all the cards beneath this card and retire it to gain a number
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to search your deck for a Troublemaker, reveal it, put it into your hand, and shuffle your deck." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and pay 1AT to search your deck for a Troublemaker, reveal it, put it into your hand, and shuffle your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3116,7 +3122,7 @@ Main Phase: Spend all the cards beneath this card and retire it to gain a number
    <property name="Rarity" value="U" />
   </card>
   <card id="51634a51-7523-4502-9d5d-b6ef22d7a5d4" name="Monstrous Manual">
-   <property name="Number" value="cn144" />
+   <property name="Number" value="CN144" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3125,8 +3131,8 @@ Main Phase: Spend all the cards beneath this card and retire it to gain a number
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Reaction: At the start of your Troublemaker Phase, you may exhaust this card and pay 2 to turn a Troublemaker face-down." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Reaction: After the start of your Troublemaker Phase, you may exhaust this card and pay 2AT to turn a Troublemaker face-down." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3136,7 +3142,7 @@ Main Phase: Spend all the cards beneath this card and retire it to gain a number
    <property name="Rarity" value="C" />
   </card>
   <card id="f12c5755-4538-47dc-8246-541764d9ec7e" name="Pie Family Rock Farm">
-   <property name="Number" value="cn145" />
+   <property name="Number" value="CN145" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3145,9 +3151,8 @@ Main Phase: Spend all the cards beneath this card and retire it to gain a number
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="When this card enters play, draw a card.
-If a player would draw a card during their Ready Phase, they draw 2 cards instead." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;When this card enters play, draw a card.&#10;At the start of each player's turn, that player draws an additional card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3157,7 +3162,7 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="Rarity" value="R" />
   </card>
   <card id="7a29eadd-83b5-40d2-bb91-dfbe29ab29e0" name="Private Party">
-   <property name="Number" value="cn146" />
+   <property name="Number" value="CN146" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3166,8 +3171,8 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Reaction: After an opponent plays a Troublemaker, you may exhaust this card and pay 1 to move that face-down Troublemaker to another Problem." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Reaction: After an opponent plays a Troublemaker, you may exhaust this card and pay 1AT to move that face-down Troublemaker to another Problem." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3177,7 +3182,7 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="Rarity" value="U" />
   </card>
   <card id="834a0657-1fdf-416c-80bf-f16afbfaa640" name="Reformed">
-   <property name="Number" value="cn147" />
+   <property name="Number" value="CN147" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3186,8 +3191,8 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on an opponent's Troublemaker." />
-   <property name="Text" value="When you defeat that Troublemaker, you may add its power to your next faceoff this turn." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on an opponent's Troublemaker.&#10;When you defeat that Troublemaker, you may add its power to your next faceoff this turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3197,7 +3202,7 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="Rarity" value="U" />
   </card>
   <card id="18c8d304-3758-45eb-b1b2-98f673cb8a1c" name="Snooty Boutique">
-   <property name="Number" value="cn148" />
+   <property name="Number" value="CN148" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3206,8 +3211,8 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Location" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Reaction: After the start of a Faceoff, you may exhaust this card to put a card from your hand on the top of your deck." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Reaction: After the start of a Faceoff, you may exhaust this card to put a card from your hand on the top of your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3217,7 +3222,7 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="Rarity" value="R" />
   </card>
   <card id="dd9deab7-5ee1-423a-8217-28c57db7b871" name="Soothe the Savage Beast">
-   <property name="Number" value="cn149" />
+   <property name="Number" value="CN149" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3226,8 +3231,8 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Condition" />
-   <property name="Keywords" value="Play on an opponent's non-Epic Troublemaker." />
-   <property name="Text" value="That Troublemaker loses and can't gain abilities  during your Troublemaker Phase." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on an opponent's non-Epic Troublemaker.&#10;That Troublemaker loses and can't gain abilities during your Troublemaker Phase." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3237,7 +3242,7 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="Rarity" value="R" />
   </card>
   <card id="3af96097-bab5-4ac2-a1d9-17f58cfccfaf" name="The High Ground">
-   <property name="Number" value="cn150" />
+   <property name="Number" value="CN150" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3246,8 +3251,8 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Reaction: After a Troublemaker is played, you may ready one of your characters." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Reaction: After a Troublemaker is played, you may exhaust this card to ready one of your characters." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3257,7 +3262,7 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="Rarity" value="U" />
   </card>
   <card id="0bf632df-9024-490e-b1a7-a23d0b840565" name="The Twilicane">
-   <property name="Number" value="cn151" />
+   <property name="Number" value="CN151" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3265,9 +3270,9 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Magic" />
-   <property name="Traits" value="Location, Unique" />
-   <property name="Keywords" value="Play on an opponent's Mane Character" />
-   <property name="Text" value="During the Score Phase, if that Mane Character is at home, that opponent's Friends each have -1 power." />
+   <property name="Traits" value="Accessory, Unique" />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on an opponent's Mane Character.&#10;During the Score Phase, if that Mane Character is at home, that opponent's Friends each have -1 power." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3277,7 +3282,7 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="Rarity" value="R" />
   </card>
   <card id="1320c044-95c3-4b90-9b19-d351a02c7da3" name="Train Tracks">
-   <property name="Number" value="cn152" />
+   <property name="Number" value="CN152" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3286,10 +3291,8 @@ If a player would draw a card during their Ready Phase, they draw 2 cards instea
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Loyalty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this card and pay 1 to frighten an opponent's Friend at a Problem.
-While this card is exhausted, that card can't be unfrightened.
-Main Phase: Exhaust 2 of your characters to dismiss this card. Any player may activated this ability." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and pay 1AT to frighten an opponent's Friend at a Problem.&#10;While this card is exhausted, that card can't be unfrightened.&#10;Main Phase: Exhaust 2 of your characters to dismiss this card. Any player may activate this ability." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3299,7 +3302,7 @@ Main Phase: Exhaust 2 of your characters to dismiss this card. Any player may ac
    <property name="Rarity" value="R" />
   </card>
   <card id="0e21d2d1-39eb-4f82-96de-0a4d66049aa2" name="Varmint Barricade">
-   <property name="Number" value="cn153" />
+   <property name="Number" value="CN153" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3308,9 +3311,8 @@ Main Phase: Exhaust 2 of your characters to dismiss this card. Any player may ac
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="When a Troublemaker is played, banish the top card of your deck beneath this card.
-Main Phase: Spend a card from beneath this card to move one of your characters to a Problem with a Troublemaker." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your Home.&#10;When a Troublemaker is played, banish the top card of your deck to beneath this card.&#10;Main Phase: Spend a card from beneath this card to move one of your characters to a Problem with a Troublemaker." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3320,7 +3322,7 @@ Main Phase: Spend a card from beneath this card to move one of your characters t
    <property name="Rarity" value="R" />
   </card>
   <card id="d438002e-9bfe-4a91-94b9-c831b8fd3c78" name="Vittles Stand">
-   <property name="Number" value="cn154" />
+   <property name="Number" value="CN154" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3329,8 +3331,8 @@ Main Phase: Spend a card from beneath this card to move one of your characters t
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="Main Phase: Exhaust this cards and one of your characters to add that character's power to another character's power until the end of the turn." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home.&#10;Main Phase: Exhaust this card and one of your characters to add that character's power to another character's power until the end of the turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3340,7 +3342,7 @@ Main Phase: Spend a card from beneath this card to move one of your characters t
    <property name="Rarity" value="C" />
   </card>
   <card id="5f8fd97c-0c3e-491c-844a-4e01f94570d0" name="Welcome Wagon">
-   <property name="Number" value="cn155" />
+   <property name="Number" value="CN155" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3349,8 +3351,8 @@ Main Phase: Spend a card from beneath this card to move one of your characters t
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Asset" />
-   <property name="Keywords" value="Play on a Friend." />
-   <property name="Text" value="Reaction: After an opponent's Friend enters play at that Friend's Problem, you may retire this Resource to exhaust the played Friend." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play on a Friend.&#10;Reaction: After an opponent's Friend enters play at that Friend's Problem, you may retire this Resource to exhaust the played Friend." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3359,8 +3361,8 @@ Main Phase: Spend a card from beneath this card to move one of your characters t
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="R" />
   </card>
-  <card id="7ff293cb-e509-4bd8-b020-c8c490d90f83" name="Princess Mi Amore Cadenza">
-   <property name="Number" value="cn156" />
+  <card id="7ff293cb-e509-4bd8-b020-c8c490d90f83" name='"Princess Mi Amore Cadenza"'>
+   <property name="Number" value="CN156" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3370,7 +3372,7 @@ Main Phase: Spend a card from beneath this card to move one of your characters t
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Pay 4 to dismiss an opponent's Friend. This card is sent to that Friend's controller's home and they gain control of it." />
+   <property name="Text" value="Main Phase: Pay 4AT to dismiss an opponent's Friend. This card is sent to that Friend's controller's home and they gain control of it." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3380,7 +3382,7 @@ Main Phase: Spend a card from beneath this card to move one of your characters t
    <property name="Rarity" value="R" />
   </card>
   <card id="b07536ca-fb83-45ac-9597-a6b86d4e8d6d" name="Changeling Infiltrator">
-   <property name="Number" value="cn157" />
+   <property name="Number" value="CN157" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3390,8 +3392,7 @@ Main Phase: Spend a card from beneath this card to move one of your characters t
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you play this card to a Problem, you may retire a Friend there to uncover this card.
-When this card is uncovered, all players shuffle their discard piles into their decks." />
+   <property name="Text" value="When you play this card to a Problem, you may retire a Friend there to uncover this card.&#10;When this card is uncovered, all players shuffle their discard piles into their decks." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3401,7 +3402,7 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="Rarity" value="R" />
   </card>
   <card id="3589d44e-608b-4ffc-896d-08407b024d23" name="Changeling Swarm">
-   <property name="Number" value="cn158" />
+   <property name="Number" value="CN158" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3420,8 +3421,8 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="U" />
   </card>
-  <card id="237ae7cb-9775-4f81-959d-a20752f56089" name="Jet Set and Upper Crust">
-   <property name="Number" value="cn159" />
+  <card id="237ae7cb-9775-4f81-959d-a20752f56089" name="Jet Set &amp; Upper Crust">
+   <property name="Number" value="CN159" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3441,7 +3442,7 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="Rarity" value="C" />
   </card>
   <card id="db2d540a-78b8-4f39-bd4e-b1c4fbb35f6d" name="Lightning Dust">
-   <property name="Number" value="cn160" />
+   <property name="Number" value="CN160" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3461,7 +3462,7 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="Rarity" value="C" />
   </card>
   <card id="a44739af-fb7f-4a38-94aa-b0d6d1ca5ba9" name="Pony of Shadows">
-   <property name="Number" value="cn161" />
+   <property name="Number" value="CN161" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3481,7 +3482,7 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="Rarity" value="U" />
   </card>
   <card id="b34da451-a774-4219-a03b-aa56322c5f61" name="Prince Blueblood">
-   <property name="Number" value="cn162" />
+   <property name="Number" value="CN162" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3501,7 +3502,7 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="Rarity" value="U" />
   </card>
   <card id="97b10a63-e53d-4899-a643-c2a9e9e91f31" name="Red Dragon">
-   <property name="Number" value="cn163" />
+   <property name="Number" value="CN163" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3511,7 +3512,7 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="At the start of your opponent's Troublemaker Phase, they may pay 2 to turn this card face-down." />
+   <property name="Text" value="At the start of your opponent's Troublemaker Phase, they may pay 2AT to turn this card face-down." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3521,7 +3522,7 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="Rarity" value="U" />
   </card>
   <card id="db52b7c7-1bf8-471f-91c5-d38350004f67" name="Sunset Shimmer">
-   <property name="Number" value="cn164" />
+   <property name="Number" value="CN164" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3531,8 +3532,7 @@ When this card is uncovered, all players shuffle their discard piles into their 
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When this Troublemaker is uncovered, you may pay 3. If you do, banish an opposing Friend or Resource to beneath this card. Otherwise, dismiss this card.
-When this card leaves play or is turned face-down, put any cards beneath it into their owner's hand." />
+   <property name="Text" value="When this Troublemaker is uncovered, you may pay 3AT. If you do, banish an opposing Friend or Resource to beneath this card. Otherwise, dismiss this card.&#10;When this card leaves play or is turned face-down, put any cards beneath it into their owner's hand." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -3542,7 +3542,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="R" />
   </card>
   <card id="7ae048cf-a7f4-428d-94e6-049012209cb3" name="800 Years of Sweltering Heat">
-   <property name="Number" value="cn165" />
+   <property name="Number" value="CN165" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3552,7 +3552,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When a player confronts this Problem, that player may pay 1 to frighten an opponent's Friend here." />
+   <property name="Text" value="When a player confronts this Problem, that player may pay 1AT to frighten an opponent's Friend here." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Loyalty" />
@@ -3562,7 +3562,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="R" />
   </card>
   <card id="4922af08-172c-4137-b8d1-cd4871fda72f" name="A Stitch in Time">
-   <property name="Number" value="cn166" />
+   <property name="Number" value="CN166" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3577,12 +3577,12 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Generosity" />
    <property name="ProblemPlayerElement1Power" value="4" />
-   <property name="ProblemPlayerElement2" value=" Not Generosity" />
+   <property name="ProblemPlayerElement2" value="Not Generosity" />
    <property name="ProblemPlayerElement2Power" value="3" />
    <property name="Rarity" value="C" />
   </card>
   <card id="2335a0c1-f23b-41ec-ae27-609ca7946bfd" name="Ancient Research">
-   <property name="Number" value="cn167" />
+   <property name="Number" value="CN167" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3602,7 +3602,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="8b94a9bf-416e-44b4-961f-f0dfb47ff7ca" name="Applebucking Day">
-   <property name="Number" value="cn168" />
+   <property name="Number" value="CN168" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3612,7 +3612,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="Starting Problem." />
-   <property name="Text" value="When involved in a Problem faceoff, this card's owner's Mane Character has +2 power." />
+   <property name="Text" value="While involved in a Problem faceoff, this card's owner's Mane Character has +2 power." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Honesty" />
@@ -3622,7 +3622,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="ca52aea1-addb-4957-81c1-ef38ab4e4bbf" name="Attitude and Pizzazz!">
-   <property name="Number" value="cn169" />
+   <property name="Number" value="CN169" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3632,7 +3632,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Characters with Accessories on them have +1 power." />
+   <property name="Text" value="Characters with Accessories on them here have +1 power." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="7" />
    <property name="ProblemPlayerElement1" value="Generosity" />
@@ -3642,7 +3642,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="f6d4d13b-2bd1-40dd-a0d0-7dc2a2fd5b4d" name="Bottom of the Well">
-   <property name="Number" value="cn170" />
+   <property name="Number" value="CN170" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3652,7 +3652,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="Starting Problem." />
-   <property name="Text" value="When involved in a faceoff, this card's owner's Mane Character has +1 power." />
+   <property name="Text" value="While involved in a faceoff, this card's owner's Mane Character has +1 power." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Loyalty" />
@@ -3662,7 +3662,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="95c36823-1239-4043-9fd1-1344ab23ce79" name="Cheering Up a Friend">
-   <property name="Number" value="cn171" />
+   <property name="Number" value="CN171" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3682,7 +3682,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="fa7c9ca9-e500-43bd-9469-2aa4a499aca7" name="Cockatrice on the Loose">
-   <property name="Number" value="cn172" />
+   <property name="Number" value="CN172" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3702,7 +3702,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="R" />
   </card>
   <card id="e5e005a8-d419-4839-a8b3-a8d0888b72f1" name="Comforting Critters">
-   <property name="Number" value="cn173" />
+   <property name="Number" value="CN173" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3712,7 +3712,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="Starting Problem." />
-   <property name="Text" value="While at this problem, this card's owner's Mane Character has +1 power during the Main Phase." />
+   <property name="Text" value="While at this Problem, this card's owner's Mane Character has +1 power during the Main Phase." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="5" />
    <property name="ProblemPlayerElement1" value="Kindness" />
@@ -3722,7 +3722,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="b6bdcdb2-340a-45ff-8099-693e193d54c4" name="Crash Course">
-   <property name="Number" value="cn174" />
+   <property name="Number" value="CN174" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3742,7 +3742,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="e64c1c52-9fd5-40d9-8c2f-e84701501197" name="Dark Dank Dungeon">
-   <property name="Number" value="cn175" />
+   <property name="Number" value="CN175" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3762,7 +3762,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="a5209147-d48a-48db-9e29-d3a2b05d6678" name="Goof Off">
-   <property name="Number" value="cn176" />
+   <property name="Number" value="CN176" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3782,7 +3782,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="6703c98b-a675-46f2-af55-b0a0628f81d3" name="Frown Town">
-   <property name="Number" value="cn177" />
+   <property name="Number" value="CN177" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3792,7 +3792,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When a player confronts this Problem, that player reveals the top card of their deck. If it's a Friend, they put it into their hand.  Otherwise, they put it in the discard pile." />
+   <property name="Text" value="When a player confronts this Problem, that player reveals the top card of their deck. If it's a Friend, they put it into their hand. Otherwise, they put it in the discard pile." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Laughter" />
@@ -3802,7 +3802,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="36a4ff1b-2e38-47d2-b07d-a0cae3238dbe" name="Fruit Bat Roundup">
-   <property name="Number" value="cn178" />
+   <property name="Number" value="CN178" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3822,7 +3822,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="R" />
   </card>
   <card id="a4fa1313-42c2-41f7-b065-b2a5d52396ae" name="Greeting Lots of Folks With Clout">
-   <property name="Number" value="cn179" />
+   <property name="Number" value="CN179" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3832,7 +3832,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Main Phase: Pay 1 to move your opponent's Main Character here. Any player may activate this ability." />
+   <property name="Text" value="Main Phase: Pay 1AT to move your opponent's Mane Character here. Any player may activate this ability." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
    <property name="ProblemPlayerElement1" value="Magic" />
@@ -3842,7 +3842,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="ae70d650-d1f7-423f-902b-9bd65da865fb" name="Hungry Hungry House Guest">
-   <property name="Number" value="cn180" />
+   <property name="Number" value="CN180" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3862,7 +3862,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="5c03d62e-626d-429d-a6da-fde46b9e4732" name="Impress the Inspector">
-   <property name="Number" value="cn181" />
+   <property name="Number" value="CN181" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3882,7 +3882,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="03616122-4dde-492e-a7d7-f82d4768ef92" name="Lost in the Crystal Caves">
-   <property name="Number" value="cn182" />
+   <property name="Number" value="CN182" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3902,7 +3902,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="aff55558-3169-4d0f-ac0c-4d97c745cbf8" name="Out of Control">
-   <property name="Number" value="cn183" />
+   <property name="Number" value="CN183" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3922,7 +3922,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="29a094a4-ae88-4a84-a684-178a966dcb3e" name="Royal Dress Rehearsal">
-   <property name="Number" value="cn184" />
+   <property name="Number" value="CN184" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3942,7 +3942,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="45395e12-0fa0-4efe-a2f2-262d730e87ea" name="Social Obligations">
-   <property name="Number" value="cn185" />
+   <property name="Number" value="CN185" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3962,7 +3962,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="U" />
   </card>
   <card id="399a5e12-10e7-4e01-9c1d-bb720aafda1c" name="Storming the Villain's Lair">
-   <property name="Number" value="cn186" />
+   <property name="Number" value="CN186" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3972,7 +3972,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When a Troublemaker is played here, its controller may pay 2 to uncover it." />
+   <property name="Text" value="When a Troublemaker is played here, its controller may pay 2AT to uncover it." />
    <property name="ProblemBonus" value="1" />
    <property name="ProblemOpponentPower" value="4" />
    <property name="ProblemPlayerElement1" value="Loyalty" />
@@ -3982,7 +3982,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="C" />
   </card>
   <card id="aa8992df-051b-46c0-9f0b-1e5d349c0005" name="Threat Against Canterlot">
-   <property name="Number" value="cn187" />
+   <property name="Number" value="CN187" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -3992,17 +3992,17 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Once this problem has been confronted, Troublemakers can't be played here." />
+   <property name="Text" value="Once this Problem has been confronted, Troublemakers can't be played here." />
    <property name="ProblemBonus" value="2" />
    <property name="ProblemOpponentPower" value="8" />
    <property name="ProblemPlayerElement1" value="Honesty" />
    <property name="ProblemPlayerElement1Power" value="4" />
    <property name="ProblemPlayerElement2" value="Not Honesty" />
-   <property name="ProblemPlayerElement2Power" value="1" />
+   <property name="ProblemPlayerElement2Power" value="3" />
    <property name="Rarity" value="U" />
   </card>
   <card id="8da38f03-023a-4995-bb23-9c51a6a5c4d9" name="Too Many Pinkie Pies">
-   <property name="Number" value="cn188" />
+   <property name="Number" value="CN188" />
    <property name="Type" value="Problem" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -4022,7 +4022,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="R" />
   </card>
   <card id="0b1b1526-907b-4aaa-9cd9-2da1adaa3b09" name="Princess Luna">
-   <property name="Number" value="cn189" />
+   <property name="Number" value="CN189" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Dream Catcher" />
@@ -4031,8 +4031,8 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Alicorn, Royalty" />
-   <property name="Keywords" value="Home Limit 4" />
-   <property name="Text" value="Main Phase: Pay 3 to turn this card over." />
+   <property name="Keywords" value="Home Limit 4." />
+   <property name="Text" value="Main Phase: Pay 3AT to turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4040,40 +4040,39 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="UR" />
-            <alternate name="Princess Luna" type="Mane Character Boosted">
-             <property name="Number" value="cn189" />
-             <property name="Type" value="Mane Character Boosted" />
-             <property name="Element" value="Magic" />
-             <property name="Subname" value="Dream Catcher" />
-             <property name="Power" value="2" />
-             <property name="Cost" value="" />
-             <property name="PlayRequiredPower" value="" />
-             <property name="PlayRequiredElement" value="" />
-             <property name="Traits" value="Alicorn, Royalty" />
-             <property name="Keywords" value="Home Limit 4" />
-             <property name="Text" value="When this side of the card is turned face up, you may search your deck for an Event, reveal it, put it into your hand, and shuffle your deck.
-          At the start of your Main Phase, you may reveal the top card of your deck. If you do, reveal a card from your hand. If the printed power on the card from your hand is greater, put the revealed card from your deck into your hand and turn this card over." />
-             <property name="ProblemBonus" value="" />
-             <property name="ProblemOpponentPower" value="" />
-             <property name="ProblemPlayerElement1" value="" />
-             <property name="ProblemPlayerElement1Power" value="" />
-             <property name="ProblemPlayerElement2" value="" />
-             <property name="ProblemPlayerElement2Power" value="" />
-             <property name="Rarity" value="UR" />
-   	</alternate>
+   <alternate name="Princess Luna" type="Mane Character Boosted">
+    <property name="Number" value="CN189" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Magic" />
+    <property name="Subname" value="Dream Catcher" />
+    <property name="Power" value="2" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Alicorn, Royalty" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="When this side of the card is turned face up, you may search your deck for an Event, reveal it, put it into your hand, and shuffle your deck.&#10;At the start of your Main Phase, you may reveal the top card of your deck. If you do, reveal a card from your hand. If the printed power of the card from your hand is greater, put the card revealed from your deck into your hand and turn this card over." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="UR" />
+   </alternate>
   </card>
   <card id="43dcb1bd-fa9f-4696-9523-331f9fdde4bd" name="Princess Celestia">
-   <property name="Number" value="cn190" />
+   <property name="Number" value="CN190" />
    <property name="Type" value="Mane Character" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Equestrian Leader" />
-   <property name="Power" value="" />
+   <property name="Power" value="1" />
    <property name="Cost" value="" />
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Alicorn, Royalty" />
-   <property name="Keywords" value="Home Limit 4" />
-   <property name="Text" value="Main Phase: Pay 3 to turn this card over." />
+   <property name="Keywords" value="Home Limit 4." />
+   <property name="Text" value="Main Phase: Pay 3AT to turn this card over." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4081,30 +4080,29 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="UR" />
-               <alternate name="Princess Celestia" type="Mane Character Boosted">
-                <property name="Number" value="CN190" />
-                <property name="Type" value="Mane Character Boosted" />
-                <property name="Element" value="Kindness" />
-                <property name="Subname" value="Equestrian Leader" />
-                <property name="Power" value="3" />
-                <property name="Cost" value="" />
-                <property name="PlayRequiredPower" value="" />
-                <property name="PlayRequiredElement" value="" />
-                <property name="Traits" value="Alicorn, Royalty" />
-                <property name="Keywords" value="Home Limit 4" />
-                <property name="Text" value="When this side of the card is turned face up, you may ready a Resource.
-             Main Phase: Retire one of your Resources to add its power to one of your Yellow Friends until the end of this turn and turn this card over." />
-                <property name="ProblemBonus" value="" />
-                <property name="ProblemOpponentPower" value="" />
-                <property name="ProblemPlayerElement1" value="" />
-                <property name="ProblemPlayerElement1Power" value="" />
-                <property name="ProblemPlayerElement2" value="" />
-                <property name="ProblemPlayerElement2Power" value="" />
-                <property name="Rarity" value="UR" />
-  	</alternate>
+   <alternate name="Princess Celestia" type="Mane Character Boosted">
+    <property name="Number" value="CN190" />
+    <property name="Type" value="Mane Character Boosted" />
+    <property name="Element" value="Kindness" />
+    <property name="Subname" value="Equestrian Leader" />
+    <property name="Power" value="3" />
+    <property name="Cost" value="" />
+    <property name="PlayRequiredPower" value="" />
+    <property name="PlayRequiredElement" value="" />
+    <property name="Traits" value="Alicorn, Royalty" />
+    <property name="Keywords" value="Home Limit 4." />
+    <property name="Text" value="When this side of the card is turned face up, you may ready a Resource.&#10;Main Phase: Retire one of your Resources to add its power to one of your [Kindness] Friends until the end of this turn and turn this card over." />
+    <property name="ProblemBonus" value="" />
+    <property name="ProblemOpponentPower" value="" />
+    <property name="ProblemPlayerElement1" value="" />
+    <property name="ProblemPlayerElement1Power" value="" />
+    <property name="ProblemPlayerElement2" value="" />
+    <property name="ProblemPlayerElement2Power" value="" />
+    <property name="Rarity" value="UR" />
+   </alternate>
   </card>
-  <card id="5490816e-6bed-4116-9369-6122be877fcb" name="A.K. Yearling">
-   <property name="Number" value="cn191" />
+  <card id="5490816e-6bed-4116-9369-6122be877fcb" name="A. K. Yearling">
+   <property name="Number" value="CN191" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="Adventure Writer" />
@@ -4124,7 +4122,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="UR" />
   </card>
   <card id="123bd2ea-0042-4073-852f-6af1919777b0" name="Bulk Biceps">
-   <property name="Number" value="cn192" />
+   <property name="Number" value="CN192" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Loyalty" />
    <property name="Subname" value="All Muscle" />
@@ -4144,7 +4142,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="UR" />
   </card>
   <card id="288c2244-3d67-46dc-a194-619453c2add5" name="Granny Smith">
-   <property name="Number" value="cn193" />
+   <property name="Number" value="CN193" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Honesty" />
    <property name="Subname" value="Jar Judger" />
@@ -4154,7 +4152,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="Honesty" />
    <property name="Traits" value="Earth Pony, Elder" />
    <property name="Keywords" value="" />
-   <property name="Text" value="When you confront this card's Problem, you may pay 1 to choose an opponent. That opponent chooses and discards a card." />
+   <property name="Text" value="When you confront this card's Problem you may pay 1AT to choose an opponent. That opponent chooses and discards a card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4164,7 +4162,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="UR" />
   </card>
   <card id="fde6c4d0-2ead-4811-8dea-709c8ec5b7d6" name="DJ Pon-3">
-   <property name="Number" value="cn194" />
+   <property name="Number" value="CN194" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Everypony's Shufflin'" />
@@ -4184,7 +4182,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="UR" />
   </card>
   <card id="72d5501c-b975-48cf-89c6-61aa0395fd34" name="Pinkie Pie">
-   <property name="Number" value="cn195" />
+   <property name="Number" value="CN195" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Laughter" />
    <property name="Subname" value="Clonie Pie" />
@@ -4193,8 +4191,8 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Laughter" />
    <property name="Traits" value="Earth Pony" />
-   <property name="Keywords" value="Supportive 2" />
-   <property name="Text" value="Faceoff Reaction: When you flip a card, you may pay 1 to ignore that card's power and flip a new card." />
+   <property name="Keywords" value="Supportive 2." />
+   <property name="Text" value="Faceoff Reaction: After you flip a card, you may pay 1AT to ignore that card's power and flip a new card." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4204,7 +4202,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="UR" />
   </card>
   <card id="bd14641b-7517-4c04-ba65-1bebebb1ce09" name="Princess Luna">
-   <property name="Number" value="cn196" />
+   <property name="Number" value="CN196" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Mare in the Moon" />
@@ -4214,7 +4212,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Alicorn, Royalty" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Reaction: At the start of any phase, you may banish this card and put it into play at the start of your next turn." />
+   <property name="Text" value="Reaction: After the start of any phase, you may banish this card and put it into play at the start of your next turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4224,7 +4222,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="Rarity" value="UR" />
   </card>
   <card id="08c25f7c-67c0-43c2-a26d-408bb67933ca" name="Twilight Sparkle">
-   <property name="Number" value="cn197" />
+   <property name="Number" value="CN197" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Magic" />
    <property name="Subname" value="Noted Speaker" />
@@ -4234,8 +4232,7 @@ When this card leaves play or is turned face-down, put any cards beneath it into
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Unicorn" />
    <property name="Keywords" value="" />
-   <property name="Text" value="Play with the top card of your deck revealed.
-This card's power is equal to the printed power of the top card of your deck." />
+   <property name="Text" value="Play with the top card of your deck revealed.&#10;This card's power is equal to the printed power of the top card of your deck." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4245,7 +4242,7 @@ This card's power is equal to the printed power of the top card of your deck." /
    <property name="Rarity" value="UR" />
   </card>
   <card id="7f51b17a-ee9b-476c-9fa6-9748e7b94ad5" name="Fancy Pants">
-   <property name="Number" value="cn198" />
+   <property name="Number" value="CN198" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Trendsetter" />
@@ -4254,7 +4251,7 @@ This card's power is equal to the printed power of the top card of your deck." /
    <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Generosity" />
    <property name="Traits" value="Unicorn" />
-   <property name="Keywords" value="Pumped" />
+   <property name="Keywords" value="Pumped." />
    <property name="Text" value="When you win a faceoff involving this card, you may spend any number of cards from beneath this card to score a point for each card spent." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
@@ -4265,7 +4262,7 @@ This card's power is equal to the printed power of the top card of your deck." /
    <property name="Rarity" value="UR" />
   </card>
   <card id="e82be800-087f-42e9-bef6-63407dc76227" name="Sweetie Belle">
-   <property name="Number" value="cn199" />
+   <property name="Number" value="CN199" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Generosity" />
    <property name="Subname" value="Doting Sister" />
@@ -4273,7 +4270,7 @@ This card's power is equal to the printed power of the top card of your deck." /
    <property name="Cost" value="2" />
    <property name="PlayRequiredPower" value="1" />
    <property name="PlayRequiredElement" value="Generosity" />
-   <property name="Traits" value="Unicorn, Foal" />
+   <property name="Traits" value="Unicorn,Foal" />
    <property name="Keywords" value="" />
    <property name="Text" value="When you win a faceoff involving this card and Rarity, you may exhaust this card to score a point." />
    <property name="ProblemBonus" value="" />
@@ -4285,15 +4282,15 @@ This card's power is equal to the printed power of the top card of your deck." /
    <property name="Rarity" value="UR" />
   </card>
   <card id="2cb4a561-ef3e-4e28-b98a-15f7678154d3" name="Princess Celestia">
-   <property name="Number" value="cn200" />
+   <property name="Number" value="CN200" />
    <property name="Type" value="Friend" />
    <property name="Element" value="Kindness" />
    <property name="Subname" value="Protector of Equestria" />
    <property name="Power" value="3" />
    <property name="Cost" value="3" />
-   <property name="PlayRequiredPower" value="3" />
+   <property name="PlayRequiredPower" value="2" />
    <property name="PlayRequiredElement" value="Kindness" />
-   <property name="Traits" value="Alicorn, Royalty" />
+   <property name="Traits" value="Alicorn,Royalty" />
    <property name="Keywords" value="" />
    <property name="Text" value="When this card enters play at a Problem with an opponent's Troublemaker, this card gets +2 power until the end of the turn. Challenge that Troublemaker with this card." />
    <property name="ProblemBonus" value="" />
@@ -4305,7 +4302,7 @@ This card's power is equal to the printed power of the top card of your deck." /
    <property name="Rarity" value="UR" />
   </card>
   <card id="8005af8a-2c34-4913-8656-e82e385d8e02" name="The Element of Kindness">
-   <property name="Number" value="cn201" />
+   <property name="Number" value="CN201" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="Sharing Kindness" />
@@ -4314,10 +4311,8 @@ This card's power is equal to the printed power of the top card of your deck." /
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Kindness" />
    <property name="Traits" value="Artifact, Unique" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="You must control Fluttershy to play this card.
-At the start of your turn, put a Harmony token on this card.
-Reaction: After you play a Friend with 2 or less power, you may remove 1 Harmony token from this card to give that Friend +2 power until the end of turn." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home. You must control Fluttershy to play this card.&#10;At the start of your turn, put a Harmony counter on this card.&#10;Reaction: After you play a Friend with 2 or less power, you may remove 1 Harmony counter from this card to give that Friend +2 power until the end of turn." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4327,7 +4322,7 @@ Reaction: After you play a Friend with 2 or less power, you may remove 1 Harmony
    <property name="Rarity" value="UR" />
   </card>
   <card id="4a962f26-8c61-4f99-acce-b4c3dc8f2e59" name="The Element of Magic">
-   <property name="Number" value="cn202" />
+   <property name="Number" value="CN202" />
    <property name="Type" value="Resource" />
    <property name="Element" value="" />
    <property name="Subname" value="Complete Magic" />
@@ -4336,10 +4331,8 @@ Reaction: After you play a Friend with 2 or less power, you may remove 1 Harmony
    <property name="PlayRequiredPower" value="3" />
    <property name="PlayRequiredElement" value="Magic" />
    <property name="Traits" value="Artifact, Unique" />
-   <property name="Keywords" value="Play to your home." />
-   <property name="Text" value="You must control Twilight Sparkle to play this card.
-At the start of your turn, put a Harmony token on this card.
-Main Phase: Remove 2 Harmony tokens from this card to look at the top 3 cards of your deck.  You may put any number of them on top of your deck in any order and the rest on the bottom of your deck in any order." />
+   <property name="Keywords" value="" />
+   <property name="Text" value="Play to your home. You must control Twilight Sparkle to play this card.&#10;At the start of your turn, put a Harmony counter on this card.&#10;Main Phase: Remove 2 Harmony counter from this card to look at the top 3 cards of your deck. You may put any number of them on top of your deck in any order and the rest on the bottom of your deck in any order." />
    <property name="ProblemBonus" value="" />
    <property name="ProblemOpponentPower" value="" />
    <property name="ProblemPlayerElement1" value="" />
@@ -4349,7 +4342,7 @@ Main Phase: Remove 2 Harmony tokens from this card to look at the top 3 cards of
    <property name="Rarity" value="UR" />
   </card>
   <card id="71865064-f37f-412c-ae22-8a2074fb8db1" name="Queen Chrysalis">
-   <property name="Number" value="cn203" />
+   <property name="Number" value="CN203" />
    <property name="Type" value="Troublemaker" />
    <property name="Element" value="" />
    <property name="Subname" value="" />
@@ -4358,7 +4351,7 @@ Main Phase: Remove 2 Harmony tokens from this card to look at the top 3 cards of
    <property name="PlayRequiredPower" value="" />
    <property name="PlayRequiredElement" value="" />
    <property name="Traits" value="Epic" />
-   <property name="Keywords" value="Villain" />
+   <property name="Keywords" value="Villain." />
    <property name="Text" value="At the start of a faceoff involving this card, exhaust a random character involved in the faceoff." />
    <property name="ProblemBonus" value="3" />
    <property name="ProblemOpponentPower" value="" />
@@ -4367,27 +4360,6 @@ Main Phase: Remove 2 Harmony tokens from this card to look at the top 3 cards of
    <property name="ProblemPlayerElement2" value="" />
    <property name="ProblemPlayerElement2Power" value="" />
    <property name="Rarity" value="UR" />
-  </card>
-  <card id="43f49090-675d-48a1-8af2-1efbe5be5c1f" name="Flutterbat">
-   <property name="Number" value="cn0" />
-   <property name="Type" value="Troublemaker" />
-   <property name="Element" value="" />
-   <property name="Subname" value="" />
-   <property name="Power" value="5" />
-   <property name="Cost" value="" />
-   <property name="PlayRequiredPower" value="" />
-   <property name="PlayRequiredElement" value="" />
-   <property name="Traits" value="" />
-   <property name="Keywords" value="" />
-   <property name="Text" value="When this card is uncovered, move it to another problem.
-At the start of your opponent's Troublemaker phase, move this card to a Problem with a number of characters equal to or less than the number of characters at this card's Problem." />
-   <property name="ProblemBonus" value="2" />
-   <property name="ProblemOpponentPower" value="" />
-   <property name="ProblemPlayerElement1" value="" />
-   <property name="ProblemPlayerElement1Power" value="" />
-   <property name="ProblemPlayerElement2" value="" />
-   <property name="ProblemPlayerElement2Power" value="" />
-   <property name="Rarity" value="R" />
   </card>
  </cards>
 </set>


### PR DESCRIPTION
Cleanups are mostly matching up the Number field with CG, and replacing hard newlines with XML newlines.

The rest of the changes are due to this being based on the OCR. If any of these are undesired, I can add extra code to fix most of them. Some changes are only differentiated on the printed card and aren't represented in the OCR.

Some cards were re-ordered to consistently put the foil cards last.

[] around traits in game text were removed as the printed cards are quite inconsistent about using the text or trait icon, and the OCR doesn't differentiate.

Play on X for resources were removed as keywords, as they aren't keywords.